### PR TITLE
Fix missing clues route module

### DIFF
--- a/server/routes/cluesWithSlug.js
+++ b/server/routes/cluesWithSlug.js
@@ -1,0 +1,7 @@
+// server/routes/cluesWithSlug.js
+// This file exists purely for backward compatibility.
+// Older versions of the code referenced `routes/cluesWithSlug` which was later
+// renamed to `routes/clues`. Requiring this file simply exports the standard
+// clues router so that existing deployments do not break.
+
+module.exports = require('./clues');


### PR DESCRIPTION
## Summary
- add `cluesWithSlug.js` as a compatibility shim that re-exports the `clues` router

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685972602a1c832892d66335b090f9fa