### PR TITLE
Fix missing clues route module

### DIFF
--- a/server/routes/cluesWithSlug.js
+++ b/server/routes/cluesWithSlug.js
@@ -1,0 +1,7 @@
+// server/routes/cluesWithSlug.js
+// This file exists purely for backward compatibility.
+// Older versions of the code referenced `routes/cluesWithSlug` which was later
+// renamed to `routes/clues`. Requiring this file simply exports the standard
+// clues router so that existing deployments do not break.
+
+module.exports = require('./clues');

--- a/server/server.js
+++ b/server/server.js
@@ -36,9 +36,12 @@ app.use(express.json());
 // Serve uploaded files from /uploads
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
-// Main API entry for handling clues without slug support
-// Using the standard clues router ensures compatibility with existing routes
-app.use('/api', require('./routes/clues'));
+// Main API entry for handling clues
+// Historically this server loaded `routes/cluesWithSlug`, which has since been
+// renamed to `routes/clues`. We keep the old path for compatibility so that
+// existing deployments or clones don't break if they still reference it.
+// The file at `routes/cluesWithSlug` simply re-exports the modern router.
+app.use('/api', require('./routes/cluesWithSlug'));
 // Onboarding and authentication routes for players
 app.use('/api/onboard', require('./routes/onboard'));
 app.use('/api/auth', require('./routes/auth'));


### PR DESCRIPTION
## Summary
- add `cluesWithSlug.js` as a compatibility shim that re-exports the `clues` router
- switch server to use the compatibility route

## Testing
- `npm start` *(fails: The `uri` parameter to `openUri()` must be a string)*
- `npm run dev` *(fails: The `uri` parameter to `openUri()` must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_685972602a1c832892d66335b090f9fa