### PR TITLE
Fix clue link slug

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { DEFAULT_GAME_SLUG } from '../config';
 
 export default function Sidebar() {
   const location = useLocation();
@@ -33,7 +34,7 @@ export default function Sidebar() {
       {token && (
         <>
           {renderLink('/dashboard', 'Dashboard')}
-          {renderLink('/clue/1', 'Hunt')}
+          {renderLink(`/${DEFAULT_GAME_SLUG}/clue/1`, 'Hunt')}
           {renderLink('/sidequests', 'Side Quests')}
           {renderLink('/roguery', 'Gallery')}
           {renderLink('/scoreboard', 'Scoreboard')}

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,0 +1,3 @@
+// Global app configuration
+// Default slug for the treasure hunt game. Change this to match your game's slug.
+export const DEFAULT_GAME_SLUG = 'the-42nd';

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { fetchMe, fetchTeam, addTeamMember } from '../services/api';
+import { DEFAULT_GAME_SLUG } from '../config';
 import TeamMemberForm from '../components/TeamMemberForm';
 
 export default function Dashboard() {
@@ -76,7 +77,7 @@ export default function Dashboard() {
       {user.isAdmin && <TeamMemberForm onAdd={handleAddMember} />}
 
       <div style={{ marginTop: '1rem' }}>
-        <a href={`/clue/${currentClue}`}>
+        <a href={`/${DEFAULT_GAME_SLUG}/clue/${currentClue}`}>
           <button>Go to Current Clue</button>
         </a>
       </div>


### PR DESCRIPTION
## Summary
- add `DEFAULT_GAME_SLUG` configuration
- update Sidebar and Dashboard to use slug when linking to clues

## Testing
- `npm test --silent --passWithNoTests --if-present`

------
https://chatgpt.com/codex/tasks/task_e_6859a03390288328ad0aa63f73c8d642