### PR TITLE
Add question admin CRUD

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -13,6 +13,7 @@ import InfoPage from './pages/InfoPage';
 import ScoreboardPage from './pages/ScoreboardPage';
 import AdminGamesPage from './pages/AdminGamesPage';
 import AdminCluesPage from './pages/AdminCluesPage';
+import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
 import AdminPlayersPage from './pages/AdminPlayersPage';
 
@@ -134,6 +135,15 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminCluesPage />
+                  </AdminRoute>
+                }
+              />
+              {/* Manage trivia questions */}
+              <Route
+                path="/admin/questions"
+                element={
+                  <AdminRoute>
+                    <AdminQuestionsPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -47,6 +47,7 @@ export default function Sidebar() {
           {renderLink('/admin/dashboard', 'Admin Home')}
           {renderLink('/admin/games', 'Games')}
           {renderLink('/admin/clues', 'Clues')}
+          {renderLink('/admin/questions', 'Questions')}
           {renderLink('/admin/sidequests', 'Side Quests')}
           {renderLink('/admin/players', 'Players')}
         </>

--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import {
+  fetchQuestions,
+  createQuestion,
+  deleteQuestion
+} from '../services/api';
+
+// Simple CRUD interface for Questions
+export default function AdminQuestionsPage() {
+  // List of existing questions
+  const [questions, setQuestions] = useState([]);
+  const [title, setTitle] = useState('');
+  const [text, setText] = useState('');
+  const [options, setOptions] = useState('');
+  const [notes, setNotes] = useState('');
+  // Image file selected for upload
+  const [image, setImage] = useState(null);
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  // Fetch questions from API
+  const load = async () => {
+    const { data } = await fetchQuestions();
+    setQuestions(data);
+  };
+
+  // Submit a new question to the server
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('text', text);
+    formData.append('options', options);
+    formData.append('notes', notes);
+    if (image) formData.append('image', image);
+    await createQuestion(formData);
+    setTitle('');
+    setText('');
+    setOptions('');
+    setNotes('');
+    setImage(null);
+    load();
+  };
+
+  // Delete a question by ID
+  const handleDelete = async (id) => {
+    await deleteQuestion(id);
+    load();
+  };
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>Questions</h2>
+      <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+        />
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Question"
+          required
+        />
+        <input
+          value={options}
+          onChange={(e) => setOptions(e.target.value)}
+          placeholder="Options comma separated"
+          // Admins enter answers as a comma separated list
+        />
+        <input
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Notes"
+        />
+        <input type="file" onChange={(e) => setImage(e.target.files[0])} />
+        <button type="submit">Create</button>
+      </form>
+      <ul>
+        {questions.map((q) => (
+          <li key={q._id}>
+            {q.title} <button onClick={() => handleDelete(q._id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -89,3 +89,15 @@ export const createPlayer = (data) => axios.post('/api/admin/players', data);
 export const updatePlayer = (id, data) => axios.put(`/api/admin/players/${id}`, data);
 export const deletePlayer = (id) => axios.delete(`/api/admin/players/${id}`);
 
+// Admin CRUD for questions
+export const fetchQuestions = () => axios.get('/api/admin/questions');
+// Image uploads require multipart/form-data
+export const createQuestion = (data) =>
+  axios.post('/api/admin/questions', data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+export const updateQuestion = (id, data) =>
+  axios.put(`/api/admin/questions/${id}`, data);
+export const deleteQuestion = (id) =>
+  axios.delete(`/api/admin/questions/${id}`);
+

--- a/server/controllers/questionController.js
+++ b/server/controllers/questionController.js
@@ -1,0 +1,65 @@
+// Mongoose model representing a question document
+const Question = require('../models/Question');
+// Used to store uploaded images
+const Media = require('../models/Media');
+
+// List all questions for the admin panel
+exports.getAllQuestions = async (req, res) => {
+  try {
+    const questions = await Question.find().sort({ createdAt: 1 });
+    res.json(questions);
+  } catch (err) {
+    console.error('Error fetching questions:', err);
+    res.status(500).json({ message: 'Error fetching questions' });
+  }
+};
+
+// Create a new question with optional image upload
+exports.createQuestion = async (req, res) => {
+  const { title, text, options, notes } = req.body; // form fields
+  let imageUrl = '';
+  // If an image was uploaded include it in the record and log it to Media
+  if (req.file) {
+    imageUrl = '/uploads/' + req.file.filename;
+    await Media.create({ url: imageUrl, type: 'question', tag: 'question_image' });
+  }
+  try {
+    // Convert the comma separated list of answers into an array
+    const q = new Question({
+      title,
+      text,
+      imageUrl,
+      options: options ? options.split(',').map((o) => o.trim()) : [],
+      notes
+    });
+    await q.save();
+    res.status(201).json(q);
+  } catch (err) {
+    console.error('Error creating question:', err);
+    res.status(500).json({ message: 'Error creating question' });
+  }
+};
+
+// Update an existing question by ID
+exports.updateQuestion = async (req, res) => {
+  try {
+    const q = await Question.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!q) return res.status(404).json({ message: 'Question not found' });
+    res.json(q);
+  } catch (err) {
+    console.error('Error updating question:', err);
+    res.status(500).json({ message: 'Error updating question' });
+  }
+};
+
+// Remove a question from the database
+exports.deleteQuestion = async (req, res) => {
+  try {
+    const q = await Question.findByIdAndDelete(req.params.id);
+    if (!q) return res.status(404).json({ message: 'Question not found' });
+    res.json({ message: 'Question deleted' });
+  } catch (err) {
+    console.error('Error deleting question:', err);
+    res.status(500).json({ message: 'Error deleting question' });
+  }
+};

--- a/server/models/Question.js
+++ b/server/models/Question.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+// Basic schema describing a question used in the hunt
+const questionSchema = new mongoose.Schema(
+  {
+    title: String,       // short label shown in admin UI
+    text: String,        // the actual question text
+    imageUrl: String,    // optional photo attached to the question
+    options: [String],   // multiple‑choice answers
+    notes: String        // admin notes, never sent to players
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Question', questionSchema);

--- a/server/routes/admin/questions.js
+++ b/server/routes/admin/questions.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router(); // router for /api/admin/questions
+const adminAuth = require('../../middleware/adminAuth');
+const upload = require('../../middleware/upload');
+const {
+  getAllQuestions,
+  createQuestion,
+  updateQuestion,
+  deleteQuestion
+} = require('../../controllers/questionController');
+
+// All routes below require a valid admin JWT
+router.use(adminAuth);
+
+// List all questions
+router.get('/', getAllQuestions);
+// Create a new question (accepts optional image upload)
+router.post('/', upload.single('image'), createQuestion);
+// Update an existing question
+router.put('/:id', updateQuestion);
+// Delete a question
+router.delete('/:id', deleteQuestion);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -70,6 +70,8 @@ app.use('/api/admin', require('./routes/admin'));
 app.use('/api/admin/games',  require('./routes/admin/games'));
 app.use('/api/admin/clues',  require('./routes/admin/clues'));
 app.use('/api/admin/sidequests',  require('./routes/admin/sidequests'));
+// CRUD endpoints for question management
+app.use('/api/admin/questions',  require('./routes/admin/questions'));
 app.use('/api/admin/players',  require('./routes/admin/players'));
 app.use('/api/admin/scoreboard', require('./routes/admin/scoreboard'));
 


### PR DESCRIPTION
## Summary
- add Question model and controller with CRUD logic
- add `/api/admin/questions` route and wire it up in the server
- add React page and API helpers for managing questions
- link Questions section in sidebar and router
- document new code with inline comments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859a15111f08328bb79ed59998d1a37