### PR TITLE
Extend side quest CRUD with media support

### DIFF
--- a/client/src/pages/AdminCluesPage.js
+++ b/client/src/pages/AdminCluesPage.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+
+// Simple CRUD interface for managing clue data. Supports optional image upload.
 import {
   fetchClues,
   createClueAdmin,
@@ -9,6 +11,7 @@ export default function AdminCluesPage() {
   const [clues, setClues] = useState([]);
   const [title, setTitle] = useState('');
   const [text, setText] = useState('');
+  const [image, setImage] = useState(null);
 
   useEffect(() => {
     load();
@@ -21,9 +24,14 @@ export default function AdminCluesPage() {
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    await createClueAdmin({ title, text });
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('text', text);
+    if (image) formData.append('questionImage', image);
+    await createClueAdmin(formData);
     setTitle('');
     setText('');
+    setImage(null);
     load();
   };
 
@@ -36,8 +44,23 @@ export default function AdminCluesPage() {
     <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
       <h2>Clues</h2>
       <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
-        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" required />
-        <input value={text} onChange={(e) => setText(e.target.value)} placeholder="Text" required />
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+        />
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Text"
+          required
+        />
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setImage(e.target.files[0])}
+        />
         <button type="submit">Create</button>
       </form>
       <ul>

--- a/client/src/pages/AdminSideQuestsPage.js
+++ b/client/src/pages/AdminSideQuestsPage.js
@@ -1,4 +1,6 @@
 import React, { useEffect, useState } from 'react';
+
+// Admin interface for CRUD operations on side quests
 import {
   fetchSideQuestsAdmin,
   createSideQuestAdmin,
@@ -8,6 +10,10 @@ import {
 export default function AdminSideQuestsPage() {
   const [quests, setQuests] = useState([]);
   const [title, setTitle] = useState('');
+  const [text, setText] = useState('');
+  const [image, setImage] = useState(null);
+  const [timeLimit, setTimeLimit] = useState('');
+  const [useStopwatch, setUseStopwatch] = useState(false);
 
   useEffect(() => {
     load();
@@ -20,8 +26,18 @@ export default function AdminSideQuestsPage() {
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    await createSideQuestAdmin({ title });
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('text', text);
+    if (image) formData.append('image', image);
+    if (timeLimit) formData.append('timeLimitSeconds', timeLimit);
+    formData.append('useStopwatch', useStopwatch ? 'true' : 'false');
+    await createSideQuestAdmin(formData);
     setTitle('');
+    setText('');
+    setImage(null);
+    setTimeLimit('');
+    setUseStopwatch(false);
     load();
   };
 
@@ -34,7 +50,38 @@ export default function AdminSideQuestsPage() {
     <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
       <h2>Side Quests</h2>
       <form onSubmit={handleCreate} style={{ marginBottom: '1rem' }}>
-        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" required />
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+        />
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Text"
+          required
+        />
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setImage(e.target.files[0])}
+        />
+        <input
+          type="number"
+          min="0"
+          value={timeLimit}
+          onChange={(e) => setTimeLimit(e.target.value)}
+          placeholder="Countdown seconds"
+        />
+        <label style={{ marginLeft: '0.5rem' }}>
+          <input
+            type="checkbox"
+            checked={useStopwatch}
+            onChange={(e) => setUseStopwatch(e.target.checked)}
+          />
+          Stopwatch
+        </label>
         <button type="submit">Create</button>
       </form>
       <ul>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -73,14 +73,26 @@ export const deleteGame = (id) => axios.delete(`/api/admin/games/${id}`);
 
 // Admin CRUD for clues
 export const fetchClues = () => axios.get('/api/admin/clues');
-export const createClueAdmin = (data) => axios.post('/api/admin/clues', data);
-export const updateClueAdmin = (id, data) => axios.put(`/api/admin/clues/${id}`, data);
+export const createClueAdmin = (data) =>
+  axios.post('/api/admin/clues', data, {
+    headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
+  });
+export const updateClueAdmin = (id, data) =>
+  axios.put(`/api/admin/clues/${id}`, data, {
+    headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
+  });
 export const deleteClueAdmin = (id) => axios.delete(`/api/admin/clues/${id}`);
 
 // Admin CRUD for side quests
 export const fetchSideQuestsAdmin = () => axios.get('/api/admin/sidequests');
-export const createSideQuestAdmin = (data) => axios.post('/api/admin/sidequests', data);
-export const updateSideQuestAdmin = (id, data) => axios.put(`/api/admin/sidequests/${id}`, data);
+export const createSideQuestAdmin = (data) =>
+  axios.post('/api/admin/sidequests', data, {
+    headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
+  });
+export const updateSideQuestAdmin = (id, data) =>
+  axios.put(`/api/admin/sidequests/${id}`, data, {
+    headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
+  });
 export const deleteSideQuestAdmin = (id) => axios.delete(`/api/admin/sidequests/${id}`);
 
 // Admin CRUD for players

--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -1,4 +1,8 @@
 const SideQuest = require('../models/SideQuest');
+const Media = require('../models/Media');
+
+// CRUD handlers for SideQuest objects. Supports optional image upload and
+// records whether a user or admin created the quest.
 
 exports.getAllSideQuests = async (req, res) => {
   try {
@@ -12,7 +16,28 @@ exports.getAllSideQuests = async (req, res) => {
 
 exports.createSideQuest = async (req, res) => {
   try {
-    const newSQ = new SideQuest(req.body);
+    let imageUrl = '';
+    // If an image was uploaded, store it and record in Media collection
+    if (req.files && req.files.image && req.files.image[0]) {
+      imageUrl = '/uploads/' + req.files.image[0].filename;
+      await Media.create({
+        url: imageUrl,
+        uploadedBy: req.user?._id || req.admin?.id,
+        type: 'sideQuest',
+        tag: 'sidequest_image'
+      });
+    }
+
+    const creatorId = req.user ? req.user._id : req.admin?.id;
+    const creatorType = req.user ? 'User' : 'Admin';
+
+    const newSQ = new SideQuest({
+      ...req.body,
+      imageUrl,
+      createdBy: creatorId,
+      createdByType: creatorType
+    });
+
     await newSQ.save();
     res.status(201).json(newSQ);
   } catch (err) {
@@ -24,7 +49,21 @@ exports.createSideQuest = async (req, res) => {
 // Update an existing side quest
 exports.updateSideQuest = async (req, res) => {
   try {
-    const sq = await SideQuest.findByIdAndUpdate(req.params.id, req.body, {
+    let updates = { ...req.body };
+
+    // Handle optional image upload
+    if (req.files && req.files.image && req.files.image[0]) {
+      const imageUrl = '/uploads/' + req.files.image[0].filename;
+      updates.imageUrl = imageUrl;
+      await Media.create({
+        url: imageUrl,
+        uploadedBy: req.user?._id || req.admin?.id,
+        type: 'sideQuest',
+        tag: 'sidequest_image'
+      });
+    }
+
+    const sq = await SideQuest.findByIdAndUpdate(req.params.id, updates, {
       new: true
     });
     if (!sq) return res.status(404).json({ message: 'Side quest not found' });

--- a/server/models/SideQuest.js
+++ b/server/models/SideQuest.js
@@ -1,12 +1,29 @@
 const mongoose = require('mongoose');
-const sideQuestSchema = new mongoose.Schema({
-  title: String,
-  description: String,
-  instructions: String,
-  qrCodeData: String,
-  timeLimitSeconds: Number,
-  requiredMediaType: { type: String, enum: ['photo', 'video'], default: 'photo' },
-  active: { type: Boolean, default: true }
-}, { timestamps: true });
+const sideQuestSchema = new mongoose.Schema(
+  {
+    title: String,
+    description: String,
+    instructions: String,
+    // Optional body text shown with the quest
+    text: String,
+    // URL of an image illustrating the quest
+    imageUrl: String,
+    qrCodeData: String,
+    // Seconds for countdown timer if enabled
+    timeLimitSeconds: Number,
+    // Enable stopwatch tracking when true
+    useStopwatch: { type: Boolean, default: false },
+    requiredMediaType: {
+      type: String,
+      enum: ['photo', 'video'],
+      default: 'photo'
+    },
+    // Reference to the creator (user or admin ID)
+    createdBy: mongoose.Schema.Types.ObjectId,
+    createdByType: { type: String, enum: ['User', 'Admin'] },
+    active: { type: Boolean, default: true }
+  },
+  { timestamps: true }
+);
 
 module.exports = mongoose.model('SideQuest', sideQuestSchema);

--- a/server/routes/admin/clues.js
+++ b/server/routes/admin/clues.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
+const upload = require('../../middleware/upload');
 const {
   getAllClues,
   createClue,
@@ -13,8 +14,8 @@ const {
 router.use(adminAuth);
 
 router.get('/', getAllClues);          // list
-router.post('/', createClue);          // create
-router.put('/:clueId', updateClue);    // update
+router.post('/', upload.fields([{ name: 'questionImage', maxCount: 1 }]), createClue);          // create
+router.put('/:clueId', upload.fields([{ name: 'questionImage', maxCount: 1 }]), updateClue);    // update
 router.delete('/:clueId', deleteClue); // delete
 
 module.exports = router;

--- a/server/routes/admin/sidequests.js
+++ b/server/routes/admin/sidequests.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
+const upload = require('../../middleware/upload');
 const {
   getAllSideQuests,
   createSideQuest,
@@ -12,8 +13,8 @@ const {
 router.use(adminAuth);
 
 router.get('/', getAllSideQuests);
-router.post('/', createSideQuest);
-router.put('/:id', updateSideQuest);
+router.post('/', upload.fields([{ name: 'image', maxCount: 1 }]), createSideQuest);
+router.put('/:id', upload.fields([{ name: 'image', maxCount: 1 }]), updateSideQuest);
 router.delete('/:id', deleteSideQuest);
 
 module.exports = router;

--- a/server/routes/sidequests.js
+++ b/server/routes/sidequests.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const auth = require('../middleware/auth');
+const upload = require('../middleware/upload');
 const {
   getAllSideQuests,
   createSideQuest
 } = require('../controllers/sideQuestController');
 
 router.get('/', auth, getAllSideQuests);
-router.post('/', auth, createSideQuest);
+router.post('/', auth, upload.fields([{ name: 'image', maxCount: 1 }]), createSideQuest);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow uploading images for clues and side quests in admin UI
- add stopwatch, countdown and creator tracking to side quest model
- support image uploads when creating/updating side quests and clues
- send multipart form data from admin pages when files are present

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859a1f14f388328884d56bc0cfc3e5e