### PR TITLE
Fix scoreboard scaling on narrow screens

### DIFF
--- a/client/src/pages/AdminDashboardPage.js
+++ b/client/src/pages/AdminDashboardPage.js
@@ -33,10 +33,11 @@ export default function AdminDashboardPage() {
         <tbody>
           {scores.map((s) => (
             <tr key={s.teamId}>
-              <td>{s.name}</td>
-              <td>{s.completedClues}</td>
-              <td>{s.completedSideQuests}</td>
-              <td>{s.score}</td>
+              {/* data-label attributes used by responsive CSS */}
+              <td data-label="Team">{s.name}</td>
+              <td data-label="Clues">{s.completedClues}</td>
+              <td data-label="Side Quests">{s.completedSideQuests}</td>
+              <td data-label="Score">{s.score}</td>
             </tr>
           ))}
         </tbody>

--- a/client/src/pages/ScoreboardPage.js
+++ b/client/src/pages/ScoreboardPage.js
@@ -36,10 +36,11 @@ export default function ScoreboardPage() {
         <tbody>
           {scores.map((s) => (
             <tr key={s.teamId}>
-              <td>{s.name}</td>
-              <td>{s.completedClues}</td>
-              <td>{s.completedSideQuests}</td>
-              <td>{s.score}</td>
+              {/* data-label attributes used by responsive CSS */}
+              <td data-label="Team">{s.name}</td>
+              <td data-label="Clues">{s.completedClues}</td>
+              <td data-label="Side Quests">{s.completedSideQuests}</td>
+              <td data-label="Score">{s.score}</td>
             </tr>
           ))}
         </tbody>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -170,3 +170,42 @@ form textarea {
     display: inline-block;   /* visible on phones */
   }
 }
+
+/* ───────────────── TABLES ───────────────── */
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.5rem;
+  text-align: left;
+}
+
+@media (max-width: 600px) {
+  /* Stack table rows vertically on very narrow screens */
+  table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    display: block;
+  }
+  thead tr {
+    display: none; /* Hide header labels */
+  }
+  td {
+    position: relative;
+    padding-left: 50%;
+  }
+  td::before {
+    content: attr(data-label);
+    position: absolute;
+    left: 0;
+    width: 50%;
+    padding-left: 0.5rem;
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive table styles
- include data-label attributes for scoreboard rows

## Testing
- `npm run build` in `client`
- `npm start` in `server` *(fails: The `uri` parameter to `openUri()` must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_6859a60d63008328a67b00703117011c