### PR TITLE
Fix admin clue uploads causing server error

### DIFF
--- a/server/controllers/clueController.js
+++ b/server/controllers/clueController.js
@@ -41,12 +41,13 @@ exports.createClue = async (req, res) => {
   // If an image was uploaded via multipart form, record it
   if (req.files && req.files.questionImage && req.files.questionImage[0]) {
     imageUrl = '/uploads/' + req.files.questionImage[0].filename;
-    await Media.create({
-      url: imageUrl,
-      uploadedBy: req.user._id,
-      type: 'question',
-      tag: 'clue_image'
-    });
+        await Media.create({
+          url: imageUrl,
+          // Record the uploader from either user or admin context
+          uploadedBy: req.user?._id || req.admin?.id,
+          type: 'question',
+          tag: 'clue_image'
+        });
   }
   try {
     const newClue = new Clue({
@@ -115,7 +116,9 @@ exports.updateClue = async (req, res) => {
       updates.imageUrl = imageUrl;
       await Media.create({
         url: imageUrl,
-        uploadedBy: req.user._id,
+        // Support uploads from either a player or an admin
+        // AdminAuth sets req.admin.id while player auth sets req.user._id
+        uploadedBy: req.user?._id || req.admin?.id,
         type: 'question',
         tag: 'clue_image'
       });


### PR DESCRIPTION
## Summary
- allow either user or admin ID when storing clue images

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6859afc35bb08328b2981b906c3e5936