### PR TITLE
Remove obsolete game slug middleware

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { DEFAULT_GAME_SLUG } from '../config';
 
 export default function Sidebar() {
   const location = useLocation();
@@ -34,7 +33,7 @@ export default function Sidebar() {
       {token && (
         <>
           {renderLink('/dashboard', 'Dashboard')}
-          {renderLink(`/${DEFAULT_GAME_SLUG}/clue/1`, 'Hunt')}
+          {renderLink('/clue/1', 'Hunt')}
           {renderLink('/sidequests', 'Side Quests')}
           {renderLink('/roguery', 'Gallery')}
           {renderLink('/scoreboard', 'Scoreboard')}

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,3 +1,0 @@
-// Global app configuration
-// Default slug for the treasure hunt game. Change this to match your game's slug.
-export const DEFAULT_GAME_SLUG = 'the-42nd';

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { fetchMe, fetchTeam, addTeamMember } from '../services/api';
-import { DEFAULT_GAME_SLUG } from '../config';
 import TeamMemberForm from '../components/TeamMemberForm';
 
 export default function Dashboard() {
@@ -77,7 +76,7 @@ export default function Dashboard() {
       {user.isAdmin && <TeamMemberForm onAdd={handleAddMember} />}
 
       <div style={{ marginTop: '1rem' }}>
-        <a href={`/${DEFAULT_GAME_SLUG}/clue/${currentClue}`}>
+        <a href={`/clue/${currentClue}`}>
           <button>Go to Current Clue</button>
         </a>
       </div>

--- a/client/src/pages/QuestionPage.js
+++ b/client/src/pages/QuestionPage.js
@@ -4,7 +4,7 @@ import { fetchClue, submitAnswer } from '../services/api';
 
 // Question view for the single active game
 export default function QuestionPage() {
-  // Only clueId remains now that game slugs were removed
+  // Grab clue ID from the URL
   const { clueId } = useParams();
   const navigate = useNavigate();
   const [clue, setClue] = useState(null);

--- a/server/routes/clues.js
+++ b/server/routes/clues.js
@@ -5,8 +5,7 @@ const router = express.Router();
 
 const auth = require('../middleware/auth');
 const upload = require('../middleware/upload');
-// These routes used to be namespaced by a game slug, but the
-// application now supports only a single active game.
+// Routes for managing and answering clues in the single game instance.
 const {
   getClue,
   getAllClues,

--- a/server/routes/cluesWithSlug.js
+++ b/server/routes/cluesWithSlug.js
@@ -1,7 +1,0 @@
-// server/routes/cluesWithSlug.js
-// This file exists purely for backward compatibility.
-// Older versions of the code referenced `routes/cluesWithSlug` which was later
-// renamed to `routes/clues`. Requiring this file simply exports the standard
-// clues router so that existing deployments do not break.
-
-module.exports = require('./clues');

--- a/server/server.js
+++ b/server/server.js
@@ -36,8 +36,7 @@ app.use(express.json());
 // Serve uploaded files from /uploads
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
-// Main API routes for clues. Previously these were namespaced by a
-// game slug but the application now assumes a single game.
+// Main API routes for clues. All requests assume a single game instance.
 app.use('/api', require('./routes/clues'));
 // Onboarding and authentication routes for players
 app.use('/api/onboard', require('./routes/onboard'));


### PR DESCRIPTION
## Summary
- drop unused game slug config
- simplify sidebar and dashboard links
- remove old slug comments
- delete compatibility router

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859b0c075488328904d2b2e626ddfa6