### PR TITLE
Add player login endpoint with JWT

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -9,5 +9,54 @@ exports.register = async (req, res) => {
 };
 
 exports.login = async (req, res) => {
-  return res.status(501).json({ message: 'Login disabled; use stored token' });
+  // Extract submitted credentials
+  const { firstName, lastName, teamName, teamPassword } = req.body;
+
+  // 1) Basic validation of required fields
+  if (!firstName || !lastName || !teamName || !teamPassword) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+
+  try {
+    // 2) Look up the team by name
+    const team = await Team.findOne({ name: teamName });
+    if (!team) {
+      return res.status(400).json({ message: 'Team not found' });
+    }
+
+    // 3) Verify the provided team password against the stored hash
+    const match = await bcrypt.compare(teamPassword, team.password);
+    if (!match) {
+      return res.status(400).json({ message: 'Incorrect team password' });
+    }
+
+    // 4) Find the user within this team using first and last name
+    const user = await User.findOne({
+      firstName,
+      lastName,
+      team: team._id
+    });
+    if (!user) {
+      return res.status(400).json({ message: 'Player not found' });
+    }
+
+    // 5) Issue a JWT containing the user id
+    const payload = { id: user._id };
+    const token = jwt.sign(payload, process.env.JWT_SECRET, {
+      expiresIn: '7d'
+    });
+
+    // 6) Return token and minimal user info (same as onboarding response)
+    return res.json({
+      token,
+      user: {
+        name: user.name,
+        team: team._id,
+        isAdmin: user.isAdmin
+      }
+    });
+  } catch (err) {
+    console.error('Login error:', err);
+    return res.status(500).json({ message: 'Server error during login' });
+  }
 };

--- a/server/controllers/onboardController.js
+++ b/server/controllers/onboardController.js
@@ -80,15 +80,21 @@ exports.onboard = async (req, res) => {
       selfieUrl = '/uploads/' + req.files.selfie[0].filename;
     }
 
-    // 2b) Create the User document, linking to this team
+    // 2b) Parse first and last name for storage
+    const [firstName, ...rest] = name.trim().split(' ');
+    const lastName = rest.join(' ');
+
+    // 2c) Create the User document, linking to this team
     const user = await User.create({
       name,
+      firstName,
+      lastName,
       photoUrl: selfieUrl,
       team: team._id,
       isAdmin: isNewTeam === 'true'  // mark as admin if they created the team
     });
 
-    // 2c) If we just created a new team, put this user in team.members
+    // 2d) If we just created a new team, put this user in team.members
     if (isNewTeam === 'true') {
       team.members.push({ name: user.name, avatarUrl: selfieUrl });
       await team.save();

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -14,7 +14,12 @@ exports.getMe = async (req, res) => {
 exports.updateMe = async (req, res) => {
   try {
     const updates = {};
-    if (req.body.name) updates.name = req.body.name;
+    if (req.body.name) {
+      updates.name = req.body.name;
+      const [firstName, ...rest] = req.body.name.trim().split(' ');
+      updates.firstName = firstName;
+      updates.lastName = rest.join(' ');
+    }
     if (req.files && req.files.selfie) {
       const avatarPath = '/uploads/' + req.files.selfie[0].filename;
       updates.photoUrl = avatarPath;
@@ -48,8 +53,12 @@ exports.getAllPlayers = async (req, res) => {
 // Create a new player attached to a team
 exports.createPlayer = async (req, res) => {
   try {
+    const [firstName, ...rest] = (req.body.name || '').trim().split(' ');
+    const lastName = rest.join(' ');
     const player = await User.create({
       name: req.body.name,
+      firstName,
+      lastName,
       team: req.body.team
     });
     res.status(201).json(player);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -4,6 +4,8 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema(
   {
     name: { type: String, required: true },
+    firstName: { type: String, default: '' },
+    lastName: { type: String, default: '' },
     photoUrl: { type: String, default: '' },            // e.g. "/uploads/uuid.jpg"
     team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team', required: true },
     isAdmin: { type: Boolean, default: false }          // true if this user created the team


### PR DESCRIPTION
## Summary
- add `firstName` and `lastName` to user schema
- store first/last names during onboarding and when admins create players
- allow players to update first/last name
- implement `/api/auth/login` for players using team password and name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859c5399b748328ae747b0caa2acccb