### PR TITLE
Add colour scheme picker to Profile

### DIFF
--- a/client/src/components/ColorSchemePicker.js
+++ b/client/src/components/ColorSchemePicker.js
@@ -1,10 +1,16 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { ThemeContext } from '../context/ThemeContext';
 
 export default function ColorSchemePicker() {
   const { theme, updateTheme } = useContext(ThemeContext);
   const [primary, setPrimary] = useState(theme.primary);
   const [secondary, setSecondary] = useState(theme.secondary);
+
+  // Keep local picker values in sync when the theme from context changes
+  useEffect(() => {
+    setPrimary(theme.primary);
+    setSecondary(theme.secondary);
+  }, [theme]);
 
   const handleSave = () => {
     updateTheme(primary, secondary);

--- a/client/src/pages/ProfilePage.js
+++ b/client/src/pages/ProfilePage.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ProfilePic from '../components/ProfilePic';
+// Component allowing a team to select and save its colour scheme
+import ColorSchemePicker from '../components/ColorSchemePicker';
 import { fetchMe, updateMe } from '../services/api';
 
 export default function ProfilePage() {
@@ -51,6 +53,12 @@ export default function ProfilePage() {
           <button type="submit">Save Changes</button>
         </form>
       </div>
+      {/*
+        The colour picker allows the team to customise its palette.
+        It uses ThemeContext.updateTheme which persists changes via
+        the /api/teams/:id/colour endpoint and updates the app theme.
+      */}
+      <ColorSchemePicker />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- sync ColorSchemePicker state with ThemeContext
- show ColorSchemePicker in the Profile page with comments

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859c547e84c832880b0fe0c33605fac