### PR TITLE
Implement side quest and rogues gallery features

### DIFF
--- a/client/src/pages/RoguesGalleryPage.js
+++ b/client/src/pages/RoguesGalleryPage.js
@@ -1,10 +1,43 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { fetchRoguesGallery } from '../services/api';
+import RogueItem from '../components/RogueItem';
 
 export default function RoguesGalleryPage() {
+  // Gallery items returned from the server
+  const [media, setMedia] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Load all uploaded media on mount
+    const load = async () => {
+      try {
+        const { data } = await fetchRoguesGallery();
+        setMedia(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+
   return (
     <div>
       <h2>Rogues Gallery</h2>
-      <p>This page is coming soon.</p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+          gap: '1rem'
+        }}
+      >
+        {media.map((m) => (
+          <RogueItem key={m._id} media={m} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/client/src/pages/SideQuestPage.js
+++ b/client/src/pages/SideQuestPage.js
@@ -1,10 +1,62 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { fetchSideQuests, submitSideQuest } from '../services/api';
+import PhotoUploader from '../components/PhotoUploader';
 
 export default function SideQuestPage() {
+  // List of available quests
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Load quest data on mount
+    const load = async () => {
+      try {
+        const { data } = await fetchSideQuests();
+        setQuests(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  // Upload media proof for a quest
+  const handleUpload = async (id, formData) => {
+    try {
+      await submitSideQuest(id, formData);
+      alert('Submission received!');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Upload failed');
+    }
+  };
+
+  if (loading) return <p>Loading…</p>;
+
   return (
     <div>
       <h2>Side Quests</h2>
-      <p>This page is coming soon.</p>
+      {quests.map((q) => (
+        <div key={q._id} style={{ marginBottom: '1rem' }}>
+          <div className="card" style={{ marginBottom: '0.5rem' }}>
+            <h3>{q.title}</h3>
+            <p>{q.text}</p>
+            {q.imageUrl && (
+              <img
+                src={q.imageUrl}
+                alt={q.title}
+                style={{ width: '100%', borderRadius: '4px' }}
+              />
+            )}
+          </div>
+          <PhotoUploader
+            label="Upload Proof"
+            requiredMediaType={q.requiredMediaType}
+            onUpload={(formData) => handleUpload(q._id, formData)}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -47,6 +47,14 @@ export const fetchClue = (clueId) => axios.get(`/api/clues/${clueId}`);
 export const submitAnswer = (clueId, answer) =>
   axios.post(`/api/clues/${clueId}/answer`, { answer });
 
+// Public/player side quest endpoints
+export const fetchSideQuests = () => axios.get('/api/sidequests/public');
+export const submitSideQuest = (id, data) =>
+  axios.post(`/api/sidequests/${id}/submit`, data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+export const fetchRoguesGallery = () => axios.get('/api/roguery');
+
 
 // Admin endpoints
 export const adminRegister = (data) =>

--- a/server/routes/sidequests.js
+++ b/server/routes/sidequests.js
@@ -4,10 +4,21 @@ const auth = require('../middleware/auth');
 const upload = require('../middleware/upload');
 const {
   getAllSideQuests,
-  createSideQuest
+  createSideQuest,
+  submitSideQuestProof
 } = require('../controllers/sideQuestController');
 
+// Authenticated player endpoint for active quests
 router.get('/', auth, getAllSideQuests);
+// Public listing of quests (no auth required)
+router.get('/public', getAllSideQuests);
 router.post('/', auth, upload.fields([{ name: 'image', maxCount: 1 }]), createSideQuest);
+// Handle quest completion with optional media upload
+router.post(
+  '/:id/submit',
+  auth,
+  upload.fields([{ name: 'sideQuestMedia', maxCount: 1 }]),
+  submitSideQuestProof
+);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add public side quest endpoint and submission handler
- show side quests and enable proof uploads
- list rogue media in the gallery
- expose new API helpers for quests and gallery

## Testing
- `npm test --silent` *(fails: no tests found)*
- `cd server && npm test --silent` *(fails: no tests found)*
- `cd ../client && npm test --silent` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6859c54e9d048328970927c3121ed05d