### PR TITLE
Add simple player login page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import SideQuestPage from './pages/SideQuestPage';
 import RoguesGalleryPage from './pages/RoguesGalleryPage';
 import InfoPage from './pages/InfoPage';
 import ScoreboardPage from './pages/ScoreboardPage';
+import LoginPage from './pages/LoginPage';
 import AdminCluesPage from './pages/AdminCluesPage';
 import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
@@ -48,8 +49,9 @@ export default function App() {
           <Sidebar />
           <div className="content">
             <Routes>
-              {/* Public Onboarding */}
+              {/* Public routes */}
               <Route path="/" element={<OnboardingPage />} />
+              <Route path="/login" element={<LoginPage />} />
 
               {/* Player routes */}
               <Route

--- a/client/src/pages/LoginPage.js
+++ b/client/src/pages/LoginPage.js
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { login } from '../services/api';
+
+// Simple login form for existing players
+export default function LoginPage() {
+  // Track input values for first and last name
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const navigate = useNavigate();
+
+  // Submit credentials to the API and handle response
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      // Send names as username/password to the login endpoint
+      const { data } = await login({ username: firstName, password: lastName });
+      // Save JWT for authenticated requests
+      localStorage.setItem('token', data.token);
+      // Redirect to the player dashboard after successful login
+      navigate('/dashboard');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="card" style={{ maxWidth: 400, margin: '2rem auto' }}>
+      <h2>Player Login</h2>
+      {/* onSubmit triggers handleSubmit above */}
+      <form onSubmit={handleSubmit}>
+        <label>First Name:</label>
+        <input
+          type="text"
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          required
+        />
+        <label>Surname:</label>
+        <input
+          type="password"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          required
+        />
+        <button type="submit">Log In</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -29,6 +29,10 @@ export const onboard = (formData) =>
   });
 export const fetchTeamsList = () => axios.get('/api/onboard/teams');
 
+// Player authentication
+// Posts first/last name credentials to obtain a JWT
+export const login = (creds) => axios.post('/api/auth/login', creds);
+
 // Player endpoints
 export const fetchMe = () => axios.get('/api/users/me');
 export const updateMe = (formData) =>


### PR DESCRIPTION
## Summary
- add `LoginPage` component for players
- support login in API service
- register `/login` route in `App.js`

## Testing
- `npm run build` in `client`
- `npm install` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6859c73642ec8328a9954e83194a6321