### PR TITLE
Add QR codes and answers to questions

### DIFF
--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -9,7 +9,13 @@ import {
 // Admin table for trivia questions with CRUD actions
 export default function AdminQuestionsPage() {
   const [questions, setQuestions] = useState([]);
-  const [newQ, setNewQ] = useState({ title: '', text: '', options: '', notes: '' });
+  const [newQ, setNewQ] = useState({
+    title: '',
+    text: '',
+    options: '',       // comma separated list of choices
+    correctAnswer: '', // exact text of the correct option
+    notes: ''
+  });
   const [editId, setEditId] = useState(null);
   const [editData, setEditData] = useState({});
   const [newImage, setNewImage] = useState(null);
@@ -29,10 +35,11 @@ export default function AdminQuestionsPage() {
     formData.append('title', newQ.title);
     formData.append('text', newQ.text);
     formData.append('options', newQ.options);
+    formData.append('correctAnswer', newQ.correctAnswer);
     formData.append('notes', newQ.notes);
     if (newImage) formData.append('image', newImage);
     await createQuestion(formData);
-    setNewQ({ title: '', text: '', options: '', notes: '' });
+    setNewQ({ title: '', text: '', options: '', correctAnswer: '', notes: '' });
     setNewImage(null);
     load();
   };
@@ -62,6 +69,8 @@ export default function AdminQuestionsPage() {
           <tr>
             <th>Title</th>
             <th>Question</th>
+            <th>Options</th>
+            <th>Answer</th>
             <th>Notes</th>
             <th>QR</th>
             <th>Actions</th>
@@ -72,9 +81,49 @@ export default function AdminQuestionsPage() {
             <tr key={q._id}>
               {editId === q._id ? (
                 <>
-                  <td><input value={editData.title} onChange={(e) => setEditData({ ...editData, title: e.target.value })} /></td>
-                  <td><input value={editData.text} onChange={(e) => setEditData({ ...editData, text: e.target.value })} /></td>
-                  <td><input value={editData.notes} onChange={(e) => setEditData({ ...editData, notes: e.target.value })} /></td>
+                  <td>
+                    <input
+                      value={editData.title}
+                      onChange={(e) =>
+                        setEditData({ ...editData, title: e.target.value })
+                      }
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.text}
+                      onChange={(e) =>
+                        setEditData({ ...editData, text: e.target.value })
+                      }
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.options}
+                      onChange={(e) =>
+                        setEditData({ ...editData, options: e.target.value })
+                      }
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.correctAnswer}
+                      onChange={(e) =>
+                        setEditData({
+                          ...editData,
+                          correctAnswer: e.target.value
+                        })
+                      }
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.notes}
+                      onChange={(e) =>
+                        setEditData({ ...editData, notes: e.target.value })
+                      }
+                    />
+                  </td>
                   <td>-</td>
                   <td>
                     <button onClick={() => handleSave(q._id)}>Save</button>
@@ -85,10 +134,35 @@ export default function AdminQuestionsPage() {
                 <>
                   <td>{q.title}</td>
                   <td>{q.text}</td>
+                  <td>{q.options ? q.options.join(', ') : '-'}</td>
+                  <td>{q.correctAnswer}</td>
                   <td>{q.notes}</td>
-                  <td>-</td>
                   <td>
-                    <button onClick={() => { setEditId(q._id); setEditData({ title: q.title, text: q.text, notes: q.notes, options: q.options?.join(', ') }); }}>Edit</button>
+                    {q.qrCodeData ? (
+                      <img
+                        src={q.qrCodeData}
+                        alt="QR"
+                        style={{ width: '50px' }}
+                      />
+                    ) : (
+                      '-'
+                    )}
+                  </td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        setEditId(q._id);
+                        setEditData({
+                          title: q.title,
+                          text: q.text,
+                          options: q.options?.join(', '),
+                          correctAnswer: q.correctAnswer,
+                          notes: q.notes
+                        });
+                      }}
+                    >
+                      Edit
+                    </button>
                     <button onClick={() => handleDelete(q._id)}>Delete</button>
                   </td>
                 </>
@@ -96,11 +170,47 @@ export default function AdminQuestionsPage() {
             </tr>
           ))}
           <tr>
-            <td><input value={newQ.title} onChange={(e) => setNewQ({ ...newQ, title: e.target.value })} placeholder="Title" /></td>
-            <td><input value={newQ.text} onChange={(e) => setNewQ({ ...newQ, text: e.target.value })} placeholder="Question" /></td>
-            <td><input value={newQ.notes} onChange={(e) => setNewQ({ ...newQ, notes: e.target.value })} placeholder="Notes" /></td>
+            <td>
+              <input
+                value={newQ.title}
+                onChange={(e) => setNewQ({ ...newQ, title: e.target.value })}
+                placeholder="Title"
+              />
+            </td>
+            <td>
+              <input
+                value={newQ.text}
+                onChange={(e) => setNewQ({ ...newQ, text: e.target.value })}
+                placeholder="Question"
+              />
+            </td>
+            <td>
+              <input
+                value={newQ.options}
+                onChange={(e) => setNewQ({ ...newQ, options: e.target.value })}
+                placeholder="a,b,c,d"
+              />
+            </td>
+            <td>
+              <input
+                value={newQ.correctAnswer}
+                onChange={(e) =>
+                  setNewQ({ ...newQ, correctAnswer: e.target.value })
+                }
+                placeholder="Correct"
+              />
+            </td>
+            <td>
+              <input
+                value={newQ.notes}
+                onChange={(e) => setNewQ({ ...newQ, notes: e.target.value })}
+                placeholder="Notes"
+              />
+            </td>
             <td>-</td>
-            <td><button onClick={handleCreate}>Add</button></td>
+            <td>
+              <button onClick={handleCreate}>Add</button>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/server/controllers/questionController.js
+++ b/server/controllers/questionController.js
@@ -2,11 +2,27 @@
 const Question = require('../models/Question');
 // Used to store uploaded images
 const Media = require('../models/Media');
+// Library for creating QR codes
+const QRCode = require('qrcode');
+
+// Base URL for QR code links (defaults to localhost)
+const QR_BASE = process.env.QR_BASE_URL || 'http://localhost:3000';
+
+// Helper to generate a QR code if one is missing
+async function ensureQrCode(question) {
+  if (!question.qrCodeData) {
+    const url = `${QR_BASE}/question/${question._id}`;
+    question.qrCodeData = await QRCode.toDataURL(url);
+    await question.save();
+  }
+}
 
 // List all questions for the admin panel
 exports.getAllQuestions = async (req, res) => {
   try {
     const questions = await Question.find().sort({ createdAt: 1 });
+    // ensure each question has an associated QR code
+    await Promise.all(questions.map((q) => ensureQrCode(q)));
     res.json(questions);
   } catch (err) {
     console.error('Error fetching questions:', err);
@@ -16,7 +32,7 @@ exports.getAllQuestions = async (req, res) => {
 
 // Create a new question with optional image upload
 exports.createQuestion = async (req, res) => {
-  const { title, text, options, notes } = req.body; // form fields
+  const { title, text, options, correctAnswer, notes } = req.body; // form fields
   let imageUrl = '';
   // If an image was uploaded include it in the record and log it to Media
   if (req.file) {
@@ -30,9 +46,11 @@ exports.createQuestion = async (req, res) => {
       text,
       imageUrl,
       options: options ? options.split(',').map((o) => o.trim()) : [],
+      correctAnswer,
       notes
     });
     await q.save();
+    await ensureQrCode(q);
     res.status(201).json(q);
   } catch (err) {
     console.error('Error creating question:', err);
@@ -43,8 +61,14 @@ exports.createQuestion = async (req, res) => {
 // Update an existing question by ID
 exports.updateQuestion = async (req, res) => {
   try {
-    const q = await Question.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const updates = { ...req.body };
+    // allow updating options with comma separated list
+    if (typeof updates.options === 'string') {
+      updates.options = updates.options.split(',').map((o) => o.trim());
+    }
+    const q = await Question.findByIdAndUpdate(req.params.id, updates, { new: true });
     if (!q) return res.status(404).json({ message: 'Question not found' });
+    await ensureQrCode(q);
     res.json(q);
   } catch (err) {
     console.error('Error updating question:', err);

--- a/server/models/Question.js
+++ b/server/models/Question.js
@@ -6,7 +6,9 @@ const questionSchema = new mongoose.Schema(
     title: String,       // short label shown in admin UI
     text: String,        // the actual question text
     imageUrl: String,    // optional photo attached to the question
-    options: [String],   // multiple‑choice answers
+    options: [String],   // multiple‑choice answers shown to players
+    correctAnswer: String, // the correct option value
+    qrCodeData: String,  // embedded data URL for the QR code
     notes: String        // admin notes, never sent to players
   },
   { timestamps: true }


### PR DESCRIPTION
## Summary
- allow questions to store a QR code and correct answer
- update admin UI for questions with options, answers, and QR preview
- ensure QR codes are generated when questions are created or edited

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859ca0fb9248328ad17da2526382892