### PR TITLE
Implement admin team CRUD

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import AdminCluesPage from './pages/AdminCluesPage';
 import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
 import AdminPlayersPage from './pages/AdminPlayersPage';
+import AdminTeamsPage from './pages/AdminTeamsPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
@@ -153,6 +154,14 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminPlayersPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/teams"
+                element={
+                  <AdminRoute>
+                    <AdminTeamsPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -48,6 +48,7 @@ export default function Sidebar() {
           {renderLink('/admin/clues', 'Clues')}
           {renderLink('/admin/questions', 'Questions')}
           {renderLink('/admin/sidequests', 'Side Quests')}
+          {renderLink('/admin/teams', 'Teams')}
           {renderLink('/admin/players', 'Players')}
         </>
       )}

--- a/client/src/pages/AdminTeamsPage.js
+++ b/client/src/pages/AdminTeamsPage.js
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import {
+  fetchTeamsAdmin,
+  createTeamAdmin,
+  updateTeamAdmin,
+  deleteTeamAdmin
+} from '../services/api';
+
+// Admin table for managing teams
+export default function AdminTeamsPage() {
+  const [teams, setTeams] = useState([]);          // list of teams
+  const [newTeam, setNewTeam] = useState({ name: '', password: '' });
+  const [editId, setEditId] = useState(null);      // id currently being edited
+  const [editData, setEditData] = useState({});    // form data for edit row
+
+  // Fetch all teams on component mount
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    const { data } = await fetchTeamsAdmin();
+    setTeams(data);
+  };
+
+  const handleCreate = async () => {
+    await createTeamAdmin(newTeam);
+    setNewTeam({ name: '', password: '' });
+    load();
+  };
+
+  const handleSave = async (id) => {
+    await updateTeamAdmin(id, editData);
+    setEditId(null);
+    setEditData({});
+    load();
+  };
+
+  const handleDelete = async (id) => {
+    await deleteTeamAdmin(id);
+    load();
+  };
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>Teams</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Password</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {teams.map((t) => (
+            <tr key={t._id}>
+              {editId === t._id ? (
+                <>
+                  <td>
+                    <input
+                      value={editData.name}
+                      onChange={(e) => setEditData({ ...editData, name: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="password"
+                      value={editData.password || ''}
+                      onChange={(e) => setEditData({ ...editData, password: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <button onClick={() => handleSave(t._id)}>Save</button>
+                    <button onClick={() => setEditId(null)}>Cancel</button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td>{t.name}</td>
+                  <td>••••••</td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        setEditId(t._id);
+                        setEditData({ name: t.name });
+                      }}
+                    >
+                      Edit
+                    </button>
+                    <button onClick={() => handleDelete(t._id)}>Delete</button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+          <tr>
+            <td>
+              <input
+                value={newTeam.name}
+                onChange={(e) => setNewTeam({ ...newTeam, name: e.target.value })}
+                placeholder="Name"
+              />
+            </td>
+            <td>
+              <input
+                type="password"
+                value={newTeam.password}
+                onChange={(e) => setNewTeam({ ...newTeam, password: e.target.value })}
+                placeholder="Password"
+              />
+            </td>
+            <td>
+              <button onClick={handleCreate}>Add</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -103,6 +103,18 @@ export const createPlayer = (data) => axios.post('/api/admin/players', data);
 export const updatePlayer = (id, data) => axios.put(`/api/admin/players/${id}`, data);
 export const deletePlayer = (id) => axios.delete(`/api/admin/players/${id}`);
 
+// Admin CRUD for teams
+export const fetchTeamsAdmin = () => axios.get('/api/admin/teams');
+export const createTeamAdmin = (data) =>
+  axios.post('/api/admin/teams', data, {
+    headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
+  });
+export const updateTeamAdmin = (id, data) =>
+  axios.put(`/api/admin/teams/${id}`, data, {
+    headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
+  });
+export const deleteTeamAdmin = (id) => axios.delete(`/api/admin/teams/${id}`);
+
 // Admin CRUD for questions
 export const fetchQuestions = () => axios.get('/api/admin/questions');
 // Image uploads require multipart/form-data

--- a/server/routes/admin/teams.js
+++ b/server/routes/admin/teams.js
@@ -1,0 +1,21 @@
+// server/routes/admin/teams.js
+const express = require('express');
+const router = express.Router();
+const adminAuth = require('../../middleware/adminAuth');
+const upload = require('../../middleware/upload');
+const {
+  getAllTeams,
+  createTeam,
+  updateTeam,
+  deleteTeam
+} = require('../../controllers/teamController');
+
+// Protect all routes with admin JWT
+router.use(adminAuth);
+
+router.get('/', getAllTeams); // list
+router.post('/', upload.fields([{ name: 'teamPhoto', maxCount: 1 }]), createTeam); // create
+router.put('/:id', upload.fields([{ name: 'teamPhoto', maxCount: 1 }]), updateTeam); // update
+router.delete('/:id', deleteTeam); // delete
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -59,6 +59,7 @@ app.use('/api/admin/sidequests',  require('./routes/admin/sidequests'));
 // CRUD endpoints for question management
 app.use('/api/admin/questions',  require('./routes/admin/questions'));
 app.use('/api/admin/players',  require('./routes/admin/players'));
+app.use('/api/admin/teams',  require('./routes/admin/teams'));
 app.use('/api/admin/scoreboard', require('./routes/admin/scoreboard'));
 
 // (If serving React in production, keep these lines. For local dev they can remain commented.)


### PR DESCRIPTION
## Summary
- add admin routes and controller handlers for teams
- create admin page for managing teams in React
- expose team APIs in client service layer
- wire up routes and sidebar links for teams

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm run build` in `server` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859cc3ad5108328b2aed3e974200a39