### PR TITLE
Add distinct sidebar sections for user and admin

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -4,6 +4,8 @@ import { Link, useLocation } from 'react-router-dom';
 export default function Sidebar() {
   const location = useLocation();
 
+  // Retrieve tokens from localStorage. If present we assume the user is
+  // authenticated as a regular player or an admin respectively.
   const token = localStorage.getItem('token');        // player token
   const adminToken = localStorage.getItem('adminToken'); // admin token
 
@@ -29,27 +31,30 @@ export default function Sidebar() {
       {/* Always‑visible home */}
       {renderLink('/', 'Home')}
 
-      {/* Player‑only links */}
+
+      {/* User section only shows when a player token is available */}
       {token && (
-        <>
+        <div className="sidebar-section">
+          <h3>User</h3>
           {renderLink('/dashboard', 'Dashboard')}
           {renderLink('/clue/1', 'Hunt')}
-          {renderLink('/sidequests', 'Side Quests')}
+          {renderLink('/sidequests', 'Side\u00A0Quests')}
           {renderLink('/roguery', 'Gallery')}
           {renderLink('/scoreboard', 'Scoreboard')}
           {renderLink('/profile', 'Profile')}
-        </>
+        </div>
       )}
 
-      {/* Admin‑only links */}
+      {/* Admin section is only visible for admin users */}
       {adminToken && (
-        <>
-          {renderLink('/admin/dashboard', 'Admin Home')}
+        <div className="sidebar-section">
+          <h3>Admin</h3>
+          {renderLink('/admin/dashboard', 'Admin\u00A0Home')}
           {renderLink('/admin/clues', 'Clues')}
           {renderLink('/admin/questions', 'Questions')}
           {renderLink('/admin/sidequests', 'Side Quests')}
           {renderLink('/admin/players', 'Players')}
-        </>
+        </div>
       )}
     </aside>
   );

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -169,13 +169,15 @@ form textarea {
   .hamburger {
     display: inline-block;   /* visible on phones */
   }
-}
+} 
 
 /* ───────────────── TABLES ───────────────── */
 table {
   width: 100%;
   border-collapse: collapse;
 }
+
+/* ───────────────── SIDEBAR SECTIONS ───────────────── */
 
 th,
 td {
@@ -208,4 +210,14 @@ td {
     padding-left: 0.5rem;
     font-weight: bold;
   }
+}
+
+/* ───────────────── SIDEBAR SECTIONS ───────────────── */
+.sidebar-section {
+  margin-top: 1rem;
+}
+
+.sidebar-section h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- highlight token retrieval with comments
- split sidebar into user/admin sections with headers
- style new sidebar sections

## Testing
- `npm run build` in `client`
- `npm install` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6859cc6ea638832899ef6a86d33ebda4