### PR TITLE
Restrict colour changes to admins

### DIFF
--- a/client/src/context/ThemeContext.js
+++ b/client/src/context/ThemeContext.js
@@ -33,25 +33,9 @@ export const ThemeProvider = ({ children }) => {
     fetchTheme();
   }, []);
 
-  const updateTheme = async (primary, secondary) => {
-    try {
-      const token = localStorage.getItem('token');
-      if (!token) return;
-      const userRes = await axios.get('/api/users/me');
-      const teamId = userRes.data.team._id;
-      await axios.put(
-        `/api/teams/${teamId}/colour`,
-        { primary, secondary },
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
-      setTheme({ primary, secondary });
-    } catch (err) {
-      console.error('Error updating theme:', err);
-    }
-  };
-
   return (
-    <ThemeContext.Provider value={{ theme, updateTheme }}>
+    // Expose only the current theme values; modifications are restricted to admin
+    <ThemeContext.Provider value={{ theme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/client/src/pages/ProfilePage.js
+++ b/client/src/pages/ProfilePage.js
@@ -1,7 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import ProfilePic from '../components/ProfilePic';
-// Component allowing a team to select and save its colour scheme
-import ColorSchemePicker from '../components/ColorSchemePicker';
 import { fetchMe, updateMe } from '../services/api';
 
 export default function ProfilePage() {
@@ -53,12 +51,7 @@ export default function ProfilePage() {
           <button type="submit">Save Changes</button>
         </form>
       </div>
-      {/*
-        The colour picker allows the team to customise its palette.
-        It uses ThemeContext.updateTheme which persists changes via
-        the /api/teams/:id/colour endpoint and updates the app theme.
-      */}
-      <ColorSchemePicker />
+      {/* Colour scheme editing removed; only admins can change theme */}
     </div>
   );
 }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -40,8 +40,6 @@ export const updateMe = (formData) =>
     headers: { 'Content-Type': 'multipart/form-data' }
   });
 export const fetchTeam = (teamId) => axios.get(`/api/teams/${teamId}`);
-export const updateTeamColour = (teamId, colours) =>
-  axios.put(`/api/teams/${teamId}/colour`, colours);
 export const addTeamMember = (teamId, formData) =>
   axios.post(`/api/teams/${teamId}/members`, formData, {
     headers: { 'Content-Type': 'multipart/form-data' }

--- a/server/routes/teams.js
+++ b/server/routes/teams.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const auth = require('../middleware/auth');
+const adminAuth = require('../middleware/adminAuth');
 const upload = require('../middleware/upload');
 const { getTeam, updateColourScheme, addMember } = require('../controllers/teamController');
 const Team = require('../models/Team');
 
 router.get('/:teamId', auth, getTeam);
-router.put('/:teamId/colour', auth, updateColourScheme);
+// Only global admins may modify a team's colour scheme
+router.put('/:teamId/colour', adminAuth, updateColourScheme);
 router.post('/:teamId/members', auth, upload.fields([{ name: 'avatar', maxCount: 1 }]), addMember);
 
 // List all teams (names and IDs) for dropdown


### PR DESCRIPTION
## Summary
- remove `ColorSchemePicker` from the player profile page
- stop exposing `updateTheme` in `ThemeContext`
- drop unused `updateTeamColour` API helper
- lock team colour update route behind admin auth

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859cd3fbe7483288cd5d43f3b8b6a9b