### PR TITLE
Implement player walls with posts and photos

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,7 @@ import RoguesGalleryPage from './pages/RoguesGalleryPage';
 import InfoPage from './pages/InfoPage';
 import ScoreboardPage from './pages/ScoreboardPage';
 import LoginPage from './pages/LoginPage';
+import PlayerWallPage from './pages/PlayerWallPage';
 import AdminCluesPage from './pages/AdminCluesPage';
 import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
@@ -92,6 +93,14 @@ export default function App() {
                 element={
                   <AuthRoute>
                     <RoguesGalleryPage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/player/:id"
+                element={
+                  <AuthRoute>
+                    <PlayerWallPage />
                   </AuthRoute>
                 }
               />

--- a/client/src/components/Wall.js
+++ b/client/src/components/Wall.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { fetchWall, postToWall } from '../services/api';
+
+// Display a player's wall and optionally allow posting
+export default function Wall({ userId, allowPost }) {
+  const [user, setUser] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [message, setMessage] = useState('');
+  const [file, setFile] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data } = await fetchWall(userId);
+        setUser(data.user);
+        setPosts(data.posts);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [userId]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const formData = new FormData();
+    if (message) formData.append('message', message);
+    if (file) formData.append('media', file);
+    try {
+      const { data } = await postToWall(userId, formData);
+      setPosts((prev) => [data, ...prev]);
+      setMessage('');
+      setFile(null);
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error posting');
+    }
+  };
+
+  if (!user) return <p>Loading…</p>;
+
+  return (
+    <div>
+      <h3>{user.name}'s Wall</h3>
+      {allowPost && (
+        <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Write a message"
+            style={{ width: '100%', minHeight: '60px' }}
+          />
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setFile(e.target.files[0])}
+          />
+          <button type="submit">Post</button>
+        </form>
+      )}
+      {posts.map((p) => (
+        <div key={p._id} className="card" style={{ marginBottom: '0.5rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            {p.author.photoUrl && (
+              <img
+                src={p.author.photoUrl}
+                alt="avatar"
+                style={{
+                  width: '40px',
+                  height: '40px',
+                  borderRadius: '50%',
+                  objectFit: 'cover',
+                  marginRight: '0.5rem'
+                }}
+              />
+            )}
+            <strong>{p.author.name}</strong>
+          </div>
+          {p.message && <p>{p.message}</p>}
+          {p.mediaUrl && (
+            <img
+              src={p.mediaUrl}
+              alt="attached"
+              style={{ maxWidth: '100%', marginTop: '0.5rem' }}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/pages/PlayerWallPage.js
+++ b/client/src/pages/PlayerWallPage.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import Wall from '../components/Wall';
+
+// Page wrapper showing another player's wall
+export default function PlayerWallPage() {
+  const { id } = useParams();
+  const token = localStorage.getItem('token');
+
+  return <Wall userId={id} allowPost={!!token} />;
+}

--- a/client/src/pages/ProfilePage.js
+++ b/client/src/pages/ProfilePage.js
@@ -3,6 +3,7 @@ import ProfilePic from '../components/ProfilePic';
 // Component allowing a team to select and save its colour scheme
 import ColorSchemePicker from '../components/ColorSchemePicker';
 import { fetchMe, updateMe } from '../services/api';
+import Wall from '../components/Wall';
 
 export default function ProfilePage() {
   const [user, setUser] = useState(null);
@@ -59,6 +60,8 @@ export default function ProfilePage() {
         the /api/teams/:id/colour endpoint and updates the app theme.
       */}
       <ColorSchemePicker />
+      {/* Display wall posts on the player's own page */}
+      <Wall userId={user._id} allowPost={true} />
     </div>
   );
 }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -59,6 +59,13 @@ export const submitSideQuest = (id, data) =>
   });
 export const fetchRoguesGallery = () => axios.get('/api/roguery');
 
+// Wall posts
+export const fetchWall = (userId) => axios.get(`/api/wall/${userId}`);
+export const postToWall = (userId, data) =>
+  axios.post(`/api/wall/${userId}`, data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+
 
 // Admin endpoints
 export const adminRegister = (data) =>

--- a/server/controllers/wallController.js
+++ b/server/controllers/wallController.js
@@ -1,0 +1,48 @@
+const WallPost = require('../models/WallPost');
+const User = require('../models/User');
+const Media = require('../models/Media');
+
+// Retrieve wall posts for a particular user
+exports.getWall = async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id).select('name photoUrl');
+    if (!user) return res.status(404).json({ message: 'User not found' });
+
+    const posts = await WallPost.find({ recipient: req.params.id })
+      .sort({ createdAt: -1 })
+      .populate('author', 'name photoUrl');
+    res.json({ user, posts });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching wall' });
+  }
+};
+
+// Create a new wall post targeting a user
+exports.createPost = async (req, res) => {
+  try {
+    let mediaUrl = '';
+    if (req.files && req.files.media && req.files.media[0]) {
+      mediaUrl = '/uploads/' + req.files.media[0].filename;
+      await Media.create({
+        url: mediaUrl,
+        uploadedBy: req.user._id,
+        team: req.user.team,
+        type: 'other',
+        tag: 'wall'
+      });
+    }
+
+    const post = await WallPost.create({
+      author: req.user._id,
+      recipient: req.params.id,
+      message: req.body.message || '',
+      mediaUrl
+    });
+    await post.populate('author', 'name photoUrl');
+    res.status(201).json(post);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error posting to wall' });
+  }
+};

--- a/server/models/WallPost.js
+++ b/server/models/WallPost.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+// Basic wall post referencing author and recipient users
+const wallPostSchema = new mongoose.Schema(
+  {
+    author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    recipient: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    message: { type: String, default: '' },
+    mediaUrl: { type: String, default: '' }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('WallPost', wallPostSchema);

--- a/server/routes/wall.js
+++ b/server/routes/wall.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const upload = require('../middleware/upload');
+const { getWall, createPost } = require('../controllers/wallController');
+
+// Public endpoint to view a user's wall
+router.get('/:id', getWall);
+
+// Authenticated endpoint to post a message or photo
+router.post('/:id', auth, upload.fields([{ name: 'media', maxCount: 1 }]), createPost);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -59,6 +59,8 @@ app.use('/api/users', require('./routes/users'));
 app.use('/api/teams', require('./routes/teams'));
 app.use('/api/sidequests', require('./routes/sidequests'));
 app.use('/api/roguery', require('./routes/roguery'));
+// Player wall posts
+app.use('/api/wall', require('./routes/wall'));
 
 // Public settings route
 app.use('/api/settings', require('./routes/settings'));


### PR DESCRIPTION
## Summary
- add WallPost mongoose model
- add wallController for posting on player walls
- create `/api/wall` routes for viewing and posting
- expose wall API helpers in client
- implement Wall component and PlayerWallPage
- show player's own wall on their profile

## Testing
- `npm -C client test` *(fails: Missing script)*
- `npm -C server test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859ceb86e3883289efc0ab432d7d100