### PR TITLE
Fix gallery uploader name

### DIFF
--- a/client/src/components/RogueItem.js
+++ b/client/src/components/RogueItem.js
@@ -15,7 +15,9 @@ function RogueItem({ media }) {
         <img src={url} alt="Media" style={{ width: '100%', borderRadius: '4px' }} />
       )}
       <div style={{ marginTop: '0.5rem' }}>
-        <strong>By:</strong> {uploadedBy?.name || 'Unknown'} <br />
+        {/* uploadedBy can be a User or Admin. Display whichever name field exists */}
+        <strong>By:</strong>{' '}
+        {uploadedBy?.name || uploadedBy?.username || 'Unknown'} <br />
         <strong>Team:</strong> {team?.name || 'N/A'} <br />
         {sideQuest && (
           <>

--- a/server/controllers/clueController.js
+++ b/server/controllers/clueController.js
@@ -63,13 +63,14 @@ exports.createClue = async (req, res) => {
   // If an image was uploaded via multipart form, record it
   if (req.files && req.files.questionImage && req.files.questionImage[0]) {
     imageUrl = '/uploads/' + req.files.questionImage[0].filename;
-        await Media.create({
-          url: imageUrl,
-          // Record the uploader from either user or admin context
-          uploadedBy: req.user?._id || req.admin?.id,
-          type: 'question',
-          tag: 'clue_image'
-        });
+      await Media.create({
+        url: imageUrl,
+        // Record the uploader from either user or admin context
+        uploadedBy: req.user?._id || req.admin?.id,
+        uploadedByModel: req.user ? 'User' : 'Admin',
+        type: 'question',
+        tag: 'clue_image'
+      });
   }
   try {
     const newClue = new Clue({
@@ -143,6 +144,7 @@ exports.updateClue = async (req, res) => {
         // Support uploads from either a player or an admin
         // AdminAuth sets req.admin.id while player auth sets req.user._id
         uploadedBy: req.user?._id || req.admin?.id,
+        uploadedByModel: req.user ? 'User' : 'Admin',
         type: 'question',
         tag: 'clue_image'
       });

--- a/server/controllers/onboardController.js
+++ b/server/controllers/onboardController.js
@@ -104,6 +104,7 @@ exports.onboard = async (req, res) => {
       await Media.create({
         url: selfieUrl,
         uploadedBy: user._id,
+        uploadedByModel: 'User',
         team: team._id,
         type: 'profile',
         tag: 'selfie'
@@ -120,6 +121,7 @@ exports.onboard = async (req, res) => {
         await Media.create({
           url: team.photoUrl,
           uploadedBy: user._id,
+          uploadedByModel: 'User',
           team: team._id,
           type: 'profile',
           tag: 'team_photo'

--- a/server/controllers/questionController.js
+++ b/server/controllers/questionController.js
@@ -21,7 +21,14 @@ exports.createQuestion = async (req, res) => {
   // If an image was uploaded include it in the record and log it to Media
   if (req.file) {
     imageUrl = '/uploads/' + req.file.filename;
-    await Media.create({ url: imageUrl, type: 'question', tag: 'question_image' });
+    await Media.create({
+      url: imageUrl,
+      uploadedBy: req.admin.id,
+      // Flag this document so the populate step knows to look in the Admin collection
+      uploadedByModel: 'Admin',
+      type: 'question',
+      tag: 'question_image'
+    });
   }
   try {
     // Convert the comma separated list of answers into an array

--- a/server/controllers/rogueController.js
+++ b/server/controllers/rogueController.js
@@ -3,7 +3,9 @@ const Media = require('../models/Media');
 exports.getAllMedia = async (req, res) => {
   try {
     const allMedia = await Media.find()
-      .populate('uploadedBy', 'name photoUrl')
+      // Populate uploader regardless of whether it's a User or Admin.
+      // We request both possible name fields so the client can display one.
+      .populate('uploadedBy', 'name username photoUrl')
       .populate('team', 'name')
       .populate('sideQuest', 'title')
       .sort({ createdAt: -1 });

--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -37,6 +37,8 @@ exports.createSideQuest = async (req, res) => {
       await Media.create({
         url: imageUrl,
         uploadedBy: req.user?._id || req.admin?.id,
+        // Dynamically indicate which model the uploader came from
+        uploadedByModel: req.user ? 'User' : 'Admin',
         type: 'sideQuest',
         tag: 'sidequest_image'
       });
@@ -73,6 +75,7 @@ exports.updateSideQuest = async (req, res) => {
       await Media.create({
         url: imageUrl,
         uploadedBy: req.user?._id || req.admin?.id,
+        uploadedByModel: req.user ? 'User' : 'Admin',
         type: 'sideQuest',
         tag: 'sidequest_image'
       });
@@ -131,6 +134,7 @@ exports.submitSideQuestProof = async (req, res) => {
       await Media.create({
         url: mediaUrl,
         uploadedBy: req.user._id,
+        uploadedByModel: 'User',
         team: team._id,
         sideQuest: sq._id,
         type: 'sideQuest',

--- a/server/controllers/teamController.js
+++ b/server/controllers/teamController.js
@@ -34,6 +34,7 @@ exports.addMember = async (req, res) => {
       await Media.create({
         url: member.avatarUrl,
         uploadedBy: req.user._id,
+        uploadedByModel: 'User',
         team: team._id,
         type: 'profile',
         tag: 'avatar'

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -26,6 +26,8 @@ exports.updateMe = async (req, res) => {
       await Media.create({
         url: avatarPath,
         uploadedBy: req.user._id,
+        // Indicate the uploader's model so the gallery can populate correctly
+        uploadedByModel: 'User',
         team: req.user.team,
         type: 'profile',
         tag: 'selfie'

--- a/server/models/Media.js
+++ b/server/models/Media.js
@@ -1,11 +1,32 @@
 const mongoose = require('mongoose');
-const mediaSchema = new mongoose.Schema({
-  url: String,
-  uploadedBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-  team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team' },
-  sideQuest: { type: mongoose.Schema.Types.ObjectId, ref: 'SideQuest' },
-  type: { type: String, enum: ['profile','question','sideQuest','other'], default: 'other' },
-  tag: String
-}, { timestamps: true });
+
+// Media documents may be uploaded by either a regular user or an admin.  Using
+// a dynamic reference via `refPath` allows us to populate the appropriate
+// collection when querying.
+const mediaSchema = new mongoose.Schema(
+  {
+    url: String,
+    // Reference to the uploader along with the model name so Mongoose knows
+    // which collection to populate from.
+    uploadedBy: {
+      type: mongoose.Schema.Types.ObjectId,
+      refPath: 'uploadedByModel'
+    },
+    uploadedByModel: {
+      type: String,
+      enum: ['User', 'Admin'],
+      default: 'User'
+    },
+    team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team' },
+    sideQuest: { type: mongoose.Schema.Types.ObjectId, ref: 'SideQuest' },
+    type: {
+      type: String,
+      enum: ['profile', 'question', 'sideQuest', 'other'],
+      default: 'other'
+    },
+    tag: String
+  },
+  { timestamps: true }
+);
 
 module.exports = mongoose.model('Media', mediaSchema);


### PR DESCRIPTION
## Summary
- support media uploads from users or admins by using mongoose refPath
- log uploader model info across controllers
- fetch both name and username for gallery items
- show username in gallery when a user name isn't present

## Testing
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_6859cf377b30832891107fe09563a561