### PR TITLE
Add QR codes and answer fields to trivia questions

### DIFF
--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -14,6 +14,7 @@ export default function AdminQuestionsPage() {
     title: '',
     text: '',
     options: '',
+    correctAnswer: '',
     notes: ''
   });
   const [editId, setEditId] = useState(null);
@@ -35,10 +36,11 @@ export default function AdminQuestionsPage() {
     formData.append('title', newQ.title);
     formData.append('text', newQ.text);
     formData.append('options', newQ.options);
+    formData.append('correctAnswer', newQ.correctAnswer);
     formData.append('notes', newQ.notes);
     if (newImage) formData.append('image', newImage);
     await createQuestion(formData);
-    setNewQ({ title: '', text: '', options: '', notes: '' });
+    setNewQ({ title: '', text: '', options: '', correctAnswer: '', notes: '' });
     setNewImage(null);
     load();
   };
@@ -68,6 +70,8 @@ export default function AdminQuestionsPage() {
           <tr>
             <th>Title</th>
             <th>Question</th>
+            <th>Options</th>
+            <th>Answer</th>
             <th>Notes</th>
             <th>Image</th>
             <th>QR</th>
@@ -79,25 +83,43 @@ export default function AdminQuestionsPage() {
             <tr key={q._id}>
               {editId === q._id ? (
                 <>
-                  <td><input value={editData.title} onChange={(e) => setEditData({ ...editData, title: e.target.value })} /></td>
-                  <td><input value={editData.text} onChange={(e) => setEditData({ ...editData, text: e.target.value })} /></td>
+                  <td>
+                    <input
+                      value={editData.title}
+                      onChange={(e) => setEditData({ ...editData, title: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.text}
+                      onChange={(e) => setEditData({ ...editData, text: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.options}
+                      onChange={(e) => setEditData({ ...editData, options: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      value={editData.correctAnswer}
+                      onChange={(e) => setEditData({ ...editData, correctAnswer: e.target.value })}
+                    />
+                  </td>
                   <td>
                     <input
                       value={editData.notes}
-                      onChange={(e) =>
-                        setEditData({ ...editData, notes: e.target.value })
-                      }
+                      onChange={(e) => setEditData({ ...editData, notes: e.target.value })}
                     />
                   </td>
                   <td>
                     {/* small preview of the attached image */}
-                    {q.imageUrl ? (
-                      <img src={q.imageUrl} alt={q.title} width={50} />
-                    ) : (
-                      '-'
-                    )}
+                    {q.imageUrl ? <img src={q.imageUrl} alt={q.title} width={50} /> : '-'}
                   </td>
-                  <td>-</td>
+                  <td>
+                    {q.qrCodeData ? <img src={q.qrCodeData} alt="QR" width={50} /> : '-'}
+                  </td>
                   <td>
                     <button onClick={() => handleSave(q._id)}>Save</button>
                     <button onClick={() => setEditId(null)}>Cancel</button>
@@ -107,18 +129,26 @@ export default function AdminQuestionsPage() {
                 <>
                   <td>{q.title}</td>
                   <td>{q.text}</td>
+                  <td>{q.options?.join(', ')}</td>
+                  <td>{q.correctAnswer || '-'}</td>
                   <td>{q.notes}</td>
+                  <td>{q.imageUrl ? <img src={q.imageUrl} alt={q.title} width={50} /> : '-'}</td>
+                  <td>{q.qrCodeData ? <img src={q.qrCodeData} alt="QR" width={50} /> : '-'}</td>
                   <td>
-                    {/* preview image if one exists */}
-                    {q.imageUrl ? (
-                      <img src={q.imageUrl} alt={q.title} width={50} />
-                    ) : (
-                      '-'
-                    )}
-                  </td>
-                  <td>-</td>
-                  <td>
-                    <button onClick={() => { setEditId(q._id); setEditData({ title: q.title, text: q.text, notes: q.notes, options: q.options?.join(', ') }); }}>Edit</button>
+                    <button
+                      onClick={() => {
+                        setEditId(q._id);
+                        setEditData({
+                          title: q.title,
+                          text: q.text,
+                          options: q.options?.join(', '),
+                          correctAnswer: q.correctAnswer,
+                          notes: q.notes
+                        });
+                      }}
+                    >
+                      Edit
+                    </button>
                     <button onClick={() => handleDelete(q._id)}>Delete</button>
                   </td>
                 </>
@@ -138,6 +168,20 @@ export default function AdminQuestionsPage() {
                 value={newQ.text}
                 onChange={(e) => setNewQ({ ...newQ, text: e.target.value })}
                 placeholder="Question"
+              />
+            </td>
+            <td>
+              <input
+                value={newQ.options}
+                onChange={(e) => setNewQ({ ...newQ, options: e.target.value })}
+                placeholder="A,B,C,D"
+              />
+            </td>
+            <td>
+              <input
+                value={newQ.correctAnswer}
+                onChange={(e) => setNewQ({ ...newQ, correctAnswer: e.target.value })}
+                placeholder="Correct option"
               />
             </td>
             <td>

--- a/server/controllers/questionController.js
+++ b/server/controllers/questionController.js
@@ -2,11 +2,31 @@
 const Question = require('../models/Question');
 // Used to store uploaded images
 const Media = require('../models/Media');
+const QRCode = require('qrcode');
+const Settings = require('../models/Settings');
+
+// Retrieve the base URL used for QR codes
+async function getQrBase() {
+  const settings = await Settings.findOne();
+  return settings?.qrBaseUrl || process.env.QR_BASE_URL || 'http://localhost:3000';
+}
+
+// Ensure a question has a QR code stored
+async function ensureQrCode(question) {
+  const base = await getQrBase();
+  const url = `${base.replace(/\/$/, '')}/question/${question._id}`;
+  if (!question.qrCodeData || question.qrBaseUrl !== base) {
+    question.qrCodeData = await QRCode.toDataURL(url);
+    question.qrBaseUrl = base;
+    await question.save();
+  }
+}
 
 // List all questions for the admin panel
 exports.getAllQuestions = async (req, res) => {
   try {
     const questions = await Question.find().sort({ createdAt: 1 });
+    await Promise.all(questions.map((q) => ensureQrCode(q)));
     res.json(questions);
   } catch (err) {
     console.error('Error fetching questions:', err);
@@ -16,7 +36,7 @@ exports.getAllQuestions = async (req, res) => {
 
 // Create a new question with optional image upload
 exports.createQuestion = async (req, res) => {
-  const { title, text, options, notes } = req.body; // form fields
+  const { title, text, options, correctAnswer, notes } = req.body; // form fields
   let imageUrl = '';
   // If an image was uploaded include it in the record and log it to Media
   if (req.file) {
@@ -30,9 +50,11 @@ exports.createQuestion = async (req, res) => {
       text,
       imageUrl,
       options: options ? options.split(',').map((o) => o.trim()) : [],
+      correctAnswer,
       notes
     });
     await q.save();
+    await ensureQrCode(q);
     res.status(201).json(q);
   } catch (err) {
     console.error('Error creating question:', err);
@@ -43,8 +65,13 @@ exports.createQuestion = async (req, res) => {
 // Update an existing question by ID
 exports.updateQuestion = async (req, res) => {
   try {
-    const q = await Question.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const updates = { ...req.body };
+    if (typeof updates.options === 'string') {
+      updates.options = updates.options.split(',').map((o) => o.trim());
+    }
+    const q = await Question.findByIdAndUpdate(req.params.id, updates, { new: true });
     if (!q) return res.status(404).json({ message: 'Question not found' });
+    await ensureQrCode(q);
     res.json(q);
   } catch (err) {
     console.error('Error updating question:', err);

--- a/server/models/Question.js
+++ b/server/models/Question.js
@@ -6,7 +6,10 @@ const questionSchema = new mongoose.Schema(
     title: String,       // short label shown in admin UI
     text: String,        // the actual question text
     imageUrl: String,    // optional photo attached to the question
-    options: [String],   // multiple‑choice answers
+    options: [String],   // multiple-choice answers
+    correctAnswer: String, // the correct option
+    qrCodeData: String,  // base64 encoded QR code
+    qrBaseUrl: String,   // base URL used when generating the QR
     notes: String        // admin notes, never sent to players
   },
   { timestamps: true }


### PR DESCRIPTION
## Summary
- store QR code info, correct answer and options in Question model
- generate QR codes for questions in controller
- expose option/answer editing and QR preview in admin UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `client/` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859d10d3de88328905eca9272939580