### PR TITLE
Fix QR base URL refresh logic

### DIFF
--- a/server/controllers/clueController.js
+++ b/server/controllers/clueController.js
@@ -5,13 +5,8 @@ const Team = require('../models/Team');
 const Media = require('../models/Media');
 const mongoose = require('mongoose');
 const QRCode = require('qrcode');
-const Settings = require('../models/Settings');
+const { getQrBase } = require('../utils/qr');
 
-// Retrieve the base URL for QR codes from settings or environment
-async function getQrBase() {
-  const settings = await Settings.findOne();
-  return settings?.qrBaseUrl || process.env.QR_BASE_URL || 'http://localhost:3000';
-}
 
 // Ensure the given clue has an up-to-date QR code based on current settings.
 async function ensureQrCode(clue) {

--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -2,14 +2,16 @@ const SideQuest = require('../models/SideQuest');
 const Media = require('../models/Media');
 const QRCode = require('qrcode');
 const Team = require('../models/Team');
-
-const QR_BASE = process.env.QR_BASE_URL || 'http://localhost:3000';
+const { getQrBase } = require('../utils/qr');
 
 // Ensure a side quest has a QR code stored
+// Ensure the QR code for a side quest reflects the current base URL
 async function ensureQrCode(sq) {
-  if (!sq.qrCodeData) {
-    const url = `${QR_BASE}/sidequest/${sq._id}`;
+  const base = await getQrBase();
+  const url = `${base.replace(/\/$/, '')}/sidequest/${sq._id}`;
+  if (!sq.qrCodeData || sq.qrBaseUrl !== base) {
     sq.qrCodeData = await QRCode.toDataURL(url);
+    sq.qrBaseUrl = base;
     await sq.save();
   }
 }

--- a/server/models/SideQuest.js
+++ b/server/models/SideQuest.js
@@ -9,6 +9,8 @@ const sideQuestSchema = new mongoose.Schema(
     // URL of an image illustrating the quest
     imageUrl: String,
     qrCodeData: String,
+    // Store the base URL used to generate qrCodeData so we know when to refresh
+    qrBaseUrl: String,
     // Seconds for countdown timer if enabled
     timeLimitSeconds: Number,
     // Enable stopwatch tracking when true

--- a/server/utils/qr.js
+++ b/server/utils/qr.js
@@ -1,0 +1,14 @@
+// server/utils/qr.js
+// Shared utilities related to QR code generation
+const Settings = require('../models/Settings');
+
+/**
+ * Retrieve the current base URL for QR code links.
+ * Falls back to the environment variable QR_BASE_URL or localhost.
+ */
+async function getQrBase() {
+  const settings = await Settings.findOne();
+  return settings?.qrBaseUrl || process.env.QR_BASE_URL || 'http://localhost:3000';
+}
+
+module.exports = { getQrBase };


### PR DESCRIPTION
## Summary
- create utility to fetch current QR base URL
- regenerate QR codes for side quests when base URL changes
- reuse QR utility in clue controller
- record QR base URL in side quest schema

## Testing
- `npm --prefix server test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859d1cc00e08328b7021468ca2930f1