### PR TITLE
Implement master reset in admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project contains a React client and an Express/MongoDB server for running a
 - Side quests and a rogues gallery for uploaded media
 - Admin authentication and dashboard endpoints
 - Team colour schemes and profile management
+- Admin settings include a **master reset** to wipe all game data after typing
+  `definitely` as confirmation
 
 ## Development notes
 - Client source in `client/` built with React

--- a/server/routes/admin/settings.js
+++ b/server/routes/admin/settings.js
@@ -2,12 +2,14 @@
 const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
-const { getSettings, updateSettings } = require('../../controllers/settingsController');
+const { getSettings, updateSettings, masterReset } = require('../../controllers/settingsController');
 
 // Protect all settings routes with admin JWT
 router.use(adminAuth);
 
 router.get('/', getSettings);
 router.put('/', updateSettings);
+// Danger zone: wipe all players, teams, questions, clues, side quests and media
+router.post('/master-reset', masterReset);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add a bullet to README describing master reset
- expand settings controller with a `masterReset` action
- expose POST `/api/admin/settings/master-reset`

## Testing
- `npm test --silent` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6859d42f929c832883734a7150ba93d4