### PR TITLE
Add admin export/import functionality

### DIFF
--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
+import {
+  fetchSettingsAdmin,
+  updateSettingsAdmin,
+  exportGameAdmin,
+  importGameAdmin
+} from '../services/api';
 
 // Page allowing admin users to configure global game settings
 export default function AdminSettingsPage() {
@@ -8,6 +13,8 @@ export default function AdminSettingsPage() {
     qrBaseUrl: '',
     theme: { primary: '#2196F3', secondary: '#FFC107' }
   });
+  // Holds the file chosen when restoring a game
+  const [importFile, setImportFile] = useState(null);
 
   // Load settings on mount
   useEffect(() => {
@@ -32,6 +39,41 @@ export default function AdminSettingsPage() {
     }
   };
 
+  // Trigger download of the current game data
+  const handleExport = async () => {
+    try {
+      // Request the export blob then create a download link on the fly
+      const { data } = await exportGameAdmin();
+      const url = window.URL.createObjectURL(new Blob([data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'game_export.json';
+      link.click();
+      // Clean up the object URL to avoid memory leaks
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      alert('Error exporting game');
+    }
+  };
+
+  // Upload a JSON file to restore the game state
+  const handleImport = async () => {
+    if (!importFile) {
+      alert('Select a file first');
+      return;
+    }
+    const formData = new FormData();
+    // Field name must match the multer middleware on the server
+    formData.append('file', importFile);
+    try {
+      // Post the file to the API and await completion
+      await importGameAdmin(formData);
+      alert('Game imported successfully');
+    } catch (err) {
+      alert('Error importing game');
+    }
+  };
+
   return (
     <div className="card" style={{ padding: '1rem', margin: '1rem', maxWidth: '500px' }}>
       <h2>Game Settings</h2>
@@ -46,6 +88,21 @@ export default function AdminSettingsPage() {
       <input type="color" value={settings.theme.secondary}
              onChange={(e) => setSettings({ ...settings, theme: { ...settings.theme, secondary: e.target.value } })} />
       <button onClick={handleSave}>Save Changes</button>
+      <hr />
+      <div style={{ marginTop: '1rem' }}>
+        <label>Import Game:</label>
+        <input
+          type="file"
+          accept="application/json"
+          onChange={(e) => setImportFile(e.target.files[0])}
+        />
+        <button onClick={handleImport} style={{ marginLeft: '0.5rem' }}>
+          Import
+        </button>
+      </div>
+      <button onClick={handleExport} style={{ marginTop: '1rem' }}>
+        Export Current Game
+      </button>
     </div>
   );
 }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -117,4 +117,9 @@ export const deleteQuestion = (id) =>
 export const fetchSettings = () => axios.get('/api/settings');
 export const fetchSettingsAdmin = () => axios.get('/api/admin/settings');
 export const updateSettingsAdmin = (data) => axios.put('/api/admin/settings', data);
+export const exportGameAdmin = () => axios.get('/api/admin/settings/export', { responseType: 'blob' });
+export const importGameAdmin = (data) =>
+  axios.post('/api/admin/settings/import', data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
 

--- a/server/controllers/settingsController.js
+++ b/server/controllers/settingsController.js
@@ -1,6 +1,14 @@
 // server/controllers/settingsController.js
 // Controller for fetching and updating global game settings
 const Settings = require('../models/Settings');
+const Admin = require('../models/Admin');
+const User = require('../models/User');
+const Team = require('../models/Team');
+const Question = require('../models/Question');
+const Clue = require('../models/Clue');
+const SideQuest = require('../models/SideQuest');
+const Media = require('../models/Media');
+const fs = require('fs').promises;
 
 // Return the singleton settings document
 exports.getSettings = async (req, res) => {
@@ -27,5 +35,79 @@ exports.updateSettings = async (req, res) => {
   } catch (err) {
     console.error('Error updating settings:', err);
     res.status(500).json({ message: 'Error updating settings' });
+  }
+};
+
+
+// Export the entire game database as a JSON file
+exports.exportGame = async (req, res) => {
+  try {
+    // Fetch all documents from each collection and store
+    // them in a single object to be stringified.
+    const data = {
+      settings: await Settings.find().lean(),
+      admins: await Admin.find().lean(),
+      users: await User.find().lean(),
+      teams: await Team.find().lean(),
+      questions: await Question.find().lean(),
+      clues: await Clue.find().lean(),
+      sideQuests: await SideQuest.find().lean(),
+      media: await Media.find().lean()
+    };
+
+    // Send the JSON as a downloadable file
+    const json = JSON.stringify(data, null, 2);
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename="game_export.json"'
+    );
+    res.send(json);
+  } catch (err) {
+    console.error('Error exporting game:', err);
+    res.status(500).json({ message: 'Error exporting game' });
+  }
+};
+
+// Import a game database from an uploaded JSON file
+exports.importGame = async (req, res) => {
+  try {
+    // A file must be provided via multipart/form-data
+    if (!req.file) {
+      return res.status(400).json({ message: 'No file uploaded' });
+    }
+
+    // Read and parse the uploaded JSON file
+    const contents = await fs.readFile(req.file.path, 'utf8');
+    const data = JSON.parse(contents);
+
+    // Wipe all collections so the import starts with a clean slate
+    await Promise.all([
+      Settings.deleteMany({}),
+      Admin.deleteMany({}),
+      User.deleteMany({}),
+      Team.deleteMany({}),
+      Question.deleteMany({}),
+      Clue.deleteMany({}),
+      SideQuest.deleteMany({}),
+      Media.deleteMany({})
+    ]);
+
+    // Insert each collection if data is present
+    if (data.settings?.length) await Settings.insertMany(data.settings);
+    if (data.admins?.length) await Admin.insertMany(data.admins);
+    if (data.users?.length) await User.insertMany(data.users);
+    if (data.teams?.length) await Team.insertMany(data.teams);
+    if (data.questions?.length) await Question.insertMany(data.questions);
+    if (data.clues?.length) await Clue.insertMany(data.clues);
+    if (data.sideQuests?.length) await SideQuest.insertMany(data.sideQuests);
+    if (data.media?.length) await Media.insertMany(data.media);
+
+    // Delete the temporary upload and confirm success
+    await fs.unlink(req.file.path);
+    res.json({ message: 'Game imported successfully' });
+  } catch (err) {
+    console.error('Error importing game:', err);
+    res.status(500).json({ message: 'Error importing game' });
   }
 };

--- a/server/routes/admin/settings.js
+++ b/server/routes/admin/settings.js
@@ -2,10 +2,19 @@
 const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
-const { getSettings, updateSettings } = require('../../controllers/settingsController');
+const {
+  getSettings,
+  updateSettings,
+  exportGame,
+  importGame
+} = require('../../controllers/settingsController');
+const upload = require('../../middleware/upload');
 
 // Protect all settings routes with admin JWT
 router.use(adminAuth);
+
+router.get('/export', exportGame);
+router.post('/import', upload.single('file'), importGame);
 
 router.get('/', getSettings);
 router.put('/', updateSettings);


### PR DESCRIPTION
## Summary
- allow admins to export and import game data
- add corresponding API calls and UI controls

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` in client
- `npm test` in server *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859d4d96d108328921c2827979ab51d