### PR TITLE
Implement Team CRUD and leader tracking

### DIFF
--- a/server/controllers/onboardController.js
+++ b/server/controllers/onboardController.js
@@ -115,6 +115,8 @@ exports.onboard = async (req, res) => {
     // and log the team photo if one was provided
     if (isNewTeam === 'true') {
       team.members.push({ name: user.name, avatarUrl: selfieUrl });
+      // Record the creator as the team leader for future authorization
+      team.leader = user._id;
       await team.save();
 
       if (team.photoUrl) {

--- a/server/controllers/teamController.js
+++ b/server/controllers/teamController.js
@@ -1,5 +1,6 @@
 const Team = require('../models/Team');
 const Media = require('../models/Media');
+const bcrypt = require('bcryptjs');
 
 exports.getTeam = async (req, res) => {
   try {
@@ -46,5 +47,103 @@ exports.addMember = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Error adding member' });
+  }
+};
+
+// ----- New CRUD handlers -----
+
+// List all teams with their leaders' names for the admin panel
+exports.getAllTeams = async (req, res) => {
+  try {
+    const teams = await Team.find().populate('leader', 'name');
+    res.json(teams);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching teams' });
+  }
+};
+
+// Create a new team. If invoked by a regular user, that user becomes the leader
+exports.createTeam = async (req, res) => {
+  try {
+    const { name, password, photoUrl } = req.body;
+    if (!name || !password) {
+      return res.status(400).json({ message: 'Missing required fields' });
+    }
+    if (await Team.findOne({ name })) {
+      return res.status(400).json({ message: 'Team name already taken' });
+    }
+
+    const hashed = await bcrypt.hash(password, 10);
+    const team = await Team.create({
+      name,
+      password: hashed,
+      photoUrl: photoUrl || '',
+      leader: req.user?._id || req.body.leader,
+      members: []
+    });
+
+    // If a user created the team, mark them as admin and add them as a member
+    if (req.user) {
+      req.user.team = team._id;
+      req.user.isAdmin = true;
+      await req.user.save();
+      team.members.push({ name: req.user.name, avatarUrl: req.user.photoUrl });
+      await team.save();
+    }
+
+    res.status(201).json(team);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error creating team' });
+  }
+};
+
+// Update an existing team. Only global admins or the team leader may edit
+exports.updateTeam = async (req, res) => {
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) return res.status(404).json({ message: 'Team not found' });
+
+    // If a user is making the request, ensure they are this team's leader
+    if (
+      req.user &&
+      (!team.leader || team.leader.toString() !== req.user._id.toString())
+    ) {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+
+    const updates = { ...req.body };
+    if (updates.password) {
+      updates.password = await bcrypt.hash(updates.password, 10);
+    }
+
+    Object.assign(team, updates);
+    await team.save();
+    res.json(team);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error updating team' });
+  }
+};
+
+// Delete a team. Only admins or the team leader may perform this action
+exports.deleteTeam = async (req, res) => {
+  try {
+    const team = await Team.findById(req.params.id);
+    if (!team) return res.status(404).json({ message: 'Team not found' });
+
+    if (
+      req.user &&
+      (!team.leader || team.leader.toString() !== req.user._id.toString())
+    ) {
+      return res.status(403).json({ message: 'Not authorized' });
+    }
+
+    await Team.deleteOne({ _id: team._id });
+    res.json({ message: 'Team deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error deleting team' });
   }
 };

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -6,6 +6,8 @@ const teamSchema = new mongoose.Schema(
     name: { type: String, required: true, unique: true },
     password: { type: String, required: true },          // bcrypt‐hashed
     photoUrl: { type: String, default: '' },             // e.g. "/uploads/uuid.jpg"
+    // Reference to the User who originally created the team
+    leader: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
     members: [
       {
         name: { type: String, required: true },

--- a/server/routes/admin/teams.js
+++ b/server/routes/admin/teams.js
@@ -1,0 +1,15 @@
+// server/routes/admin/teams.js
+const express = require('express');
+const router = express.Router();
+const adminAuth = require('../../middleware/adminAuth');
+const { getAllTeams, createTeam, updateTeam, deleteTeam } = require('../../controllers/teamController');
+
+// All team admin routes require an admin token
+router.use(adminAuth);
+
+router.get('/', getAllTeams);
+router.post('/', createTeam);
+router.put('/:id', updateTeam);
+router.delete('/:id', deleteTeam);
+
+module.exports = router;

--- a/server/routes/teams.js
+++ b/server/routes/teams.js
@@ -3,13 +3,26 @@ const router = express.Router();
 const auth = require('../middleware/auth');
 const adminAuth = require('../middleware/adminAuth');
 const upload = require('../middleware/upload');
-const { getTeam, updateColourScheme, addMember } = require('../controllers/teamController');
+const {
+  getTeam,
+  updateColourScheme,
+  addMember,
+  createTeam,
+  updateTeam,
+  deleteTeam
+} = require('../controllers/teamController');
 const Team = require('../models/Team');
 
 router.get('/:teamId', auth, getTeam);
 // Only global admins may modify a team's colour scheme
 router.put('/:teamId/colour', adminAuth, updateColourScheme);
 router.post('/:teamId/members', auth, upload.fields([{ name: 'avatar', maxCount: 1 }]), addMember);
+
+// Create a brand new team (authenticated user becomes leader)
+router.post('/', auth, createTeam);
+// Update or delete a team if the requester is its leader
+router.put('/:teamId', auth, updateTeam);
+router.delete('/:teamId', auth, deleteTeam);
 
 // List all teams (names and IDs) for dropdown
 router.get('/list/all', async (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -76,6 +76,7 @@ app.use('/api/admin/sidequests',  require('./routes/admin/sidequests'));
 // CRUD endpoints for question management
 app.use('/api/admin/questions',  require('./routes/admin/questions'));
 app.use('/api/admin/players',  require('./routes/admin/players'));
+app.use('/api/admin/teams',  require('./routes/admin/teams'));
 app.use('/api/admin/scoreboard', require('./routes/admin/scoreboard'));
 app.use('/api/admin/settings', require('./routes/admin/settings'));
 // Route allowing admins to download all uploaded media as a zip


### PR DESCRIPTION
## Summary
- add leader field to Team model
- store team leader during onboarding
- expose CRUD handlers for teams
- allow admins and team leaders to manage teams
- wire up new admin and player routes

## Testing
- `npm test` *(fails: Missing script)*
- `(client) npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a54b70b248328b2f2e04faa083fa2