### PR TITLE
Fix scoreboard crash for admins

### DIFF
--- a/server/controllers/progressController.js
+++ b/server/controllers/progressController.js
@@ -7,17 +7,21 @@ exports.getScoreboard = async (req, res) => {
     const teams = await Team.find().populate('sideQuestProgress.sideQuest', 'title');
 
     // Map to a summary object for easier consumption by the client
-    const board = teams.map(t => ({
-      teamId: t._id,
-      name: t.name,
-      completedClues: t.completedClues.length,
-      completedSideQuests: t.sideQuestProgress.length,
-      score: t.completedClues.length + t.sideQuestProgress.length
-    }))
-    // Highest score first
-    .sort((a, b) => b.score - a.score);
+    const board = teams.map(t => {
+      const clues = t.completedClues ? t.completedClues.length : 0;
+      const quests = t.sideQuestProgress ? t.sideQuestProgress.length : 0;
+      return {
+        teamId: t._id,
+        name: t.name,
+        completedClues: clues,
+        completedSideQuests: quests,
+        score: clues + quests
+      };
+    });
+    // Highest score first then return
+    const sorted = board.sort((a, b) => b.score - a.score);
 
-    res.json(board);
+    res.json(sorted);
   } catch (err) {
     console.error('Error building scoreboard:', err);
     res.status(500).json({ message: 'Error building scoreboard' });

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -16,17 +16,26 @@ const teamSchema = new mongoose.Schema(
     ],
     // You may keep any other fields you need (e.g. currentClue, colourScheme, etc.)
     currentClue: { type: Number, default: 1 },
-    completedClues: [Number],
+    // Track the numeric IDs of all solved clues
+    completedClues: {
+      type: [Number],
+      default: []
+    },
     colourScheme: {
       primary: { type: String, default: '#2196F3' },
       secondary: { type: String, default: '#FFC107' }
     },
-    sideQuestProgress: [
-      {
-        sideQuest: { type: mongoose.Schema.Types.ObjectId, ref: 'SideQuest' },
-        completedAt: Date
-      }
-    ]
+    // Log when a team completes each side quest. Defaults to an empty array so
+    // new teams won't cause runtime errors when counting completed quests.
+    sideQuestProgress: {
+      type: [
+        {
+          sideQuest: { type: mongoose.Schema.Types.ObjectId, ref: 'SideQuest' },
+          completedAt: Date
+        }
+      ],
+      default: []
+    }
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- prevent undefined fields in `Team` model
- guard scoreboard counts against missing arrays

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a57d8a2308328a986ec789fe2b342