### PR TITLE
Improve mediaController archiver handling

### DIFF
--- a/server/controllers/mediaController.js
+++ b/server/controllers/mediaController.js
@@ -1,7 +1,18 @@
 // server/controllers/mediaController.js
 // Controller handling media file operations for admins
 
-const archiver = require('archiver');
+// Attempt to load the archiver library used to create zip files. If it is
+// missing we log a clear error and rethrow so the server startup fails with
+// an informative message instead of a generic module not found error.
+let archiver;
+try {
+  archiver = require('archiver');
+} catch (err) {
+  console.error(
+    'Missing dependency "archiver". Run "npm install" in the server directory.'
+  );
+  throw err;
+}
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
## Summary
- add safe loading of the `archiver` dependency with a clear error message

## Testing
- `node -e "require('archiver'); console.log('archiver loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_685a6ea559ec8328a5b3eb06645ba552