### PR TITLE
Handle API errors in admin pages

### DIFF
--- a/client/src/pages/AdminCluesPage.js
+++ b/client/src/pages/AdminCluesPage.js
@@ -25,43 +25,67 @@ export default function AdminCluesPage() {
     load();
   }, []);
 
+  // Fetch existing clues for the list
   const load = async () => {
-    const { data } = await fetchClues();
-    setClues(data);
+    try {
+      const { data } = await fetchClues();
+      setClues(data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error loading clues');
+    }
   };
 
   // Create a new clue using the bottom row inputs
+  // Create a new clue using the form inputs
   const handleCreate = async () => {
-    const formData = new FormData();
-    formData.append('title', newClue.title);
-    formData.append('text', newClue.text);
-    formData.append('options', newClue.options);
-    formData.append('correctAnswer', newClue.correctAnswer);
-    formData.append('infoPage', newClue.infoPage ? 'true' : 'false');
-    if (newClue.image) formData.append('questionImage', newClue.image);
-    await createClueAdmin(formData);
-    setNewClue({ title: '', text: '', options: '', correctAnswer: '', infoPage: false, image: null });
-    load();
+    try {
+      const formData = new FormData();
+      formData.append('title', newClue.title);
+      formData.append('text', newClue.text);
+      formData.append('options', newClue.options);
+      formData.append('correctAnswer', newClue.correctAnswer);
+      formData.append('infoPage', newClue.infoPage ? 'true' : 'false');
+      if (newClue.image) formData.append('questionImage', newClue.image);
+      await createClueAdmin(formData);
+      setNewClue({ title: '', text: '', options: '', correctAnswer: '', infoPage: false, image: null });
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error creating clue');
+    }
   };
 
   // Save edits for an existing clue
+  // Persist edits to a clue
   const handleSave = async (id) => {
-    const formData = new FormData();
-    formData.append('title', editData.title);
-    formData.append('text', editData.text);
-    formData.append('options', editData.options);
-    formData.append('correctAnswer', editData.correctAnswer);
-    formData.append('infoPage', editData.infoPage ? 'true' : 'false');
-    if (editData.image) formData.append('questionImage', editData.image);
-    await updateClueAdmin(id, formData);
-    setEditId(null);
-    setEditData({});
-    load();
+    try {
+      const formData = new FormData();
+      formData.append('title', editData.title);
+      formData.append('text', editData.text);
+      formData.append('options', editData.options);
+      formData.append('correctAnswer', editData.correctAnswer);
+      formData.append('infoPage', editData.infoPage ? 'true' : 'false');
+      if (editData.image) formData.append('questionImage', editData.image);
+      await updateClueAdmin(id, formData);
+      setEditId(null);
+      setEditData({});
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error updating clue');
+    }
   };
 
+  // Delete a clue by ID
   const handleDelete = async (id) => {
-    await deleteClueAdmin(id);
-    load();
+    try {
+      await deleteClueAdmin(id);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error deleting clue');
+    }
   };
 
   return (

--- a/client/src/pages/AdminPlayersPage.js
+++ b/client/src/pages/AdminPlayersPage.js
@@ -14,29 +14,53 @@ export default function AdminPlayersPage() {
     load();
   }, []);
 
+  // Fetch players and available teams for the dropdown
   const load = async () => {
-    const { data } = await fetchPlayers();
-    setPlayers(data);
-    const teamRes = await fetchTeamsList();
-    setTeams(teamRes.data);
+    try {
+      const { data } = await fetchPlayers();
+      setPlayers(data);
+      const teamRes = await fetchTeamsList();
+      setTeams(teamRes.data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error loading players');
+    }
   };
 
+  // Add a new player record
   const handleCreate = async () => {
-    await createPlayer(newPlayer);
-    setNewPlayer({ name: '', team: '' });
-    load();
+    try {
+      await createPlayer(newPlayer);
+      setNewPlayer({ name: '', team: '' });
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error creating player');
+    }
   };
 
+  // Persist edits to an existing player
   const handleSave = async (id) => {
-    await updatePlayer(id, editData);
-    setEditId(null);
-    setEditData({});
-    load();
+    try {
+      await updatePlayer(id, editData);
+      setEditId(null);
+      setEditData({});
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error updating player');
+    }
   };
 
+  // Remove a player
   const handleDelete = async (id) => {
-    await deletePlayer(id);
-    load();
+    try {
+      await deletePlayer(id);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error deleting player');
+    }
   };
 
   return (

--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -26,40 +26,64 @@ export default function AdminQuestionsPage() {
     load();
   }, []);
 
+  // Fetch all existing trivia questions
   const load = async () => {
-    const { data } = await fetchQuestions();
-    setQuestions(data);
-  };
-
-  const handleCreate = async () => {
-    const formData = new FormData();
-    formData.append('title', newQ.title);
-    formData.append('text', newQ.text);
-    formData.append('options', newQ.options);
-    formData.append('correctAnswer', newQ.correctAnswer);
-    formData.append('notes', newQ.notes);
-    if (newImage) formData.append('image', newImage);
-    await createQuestion(formData);
-    setNewQ({ title: '', text: '', options: '', correctAnswer: '', notes: '' });
-    setNewImage(null);
-    load();
-  };
-
-  const handleSave = async (id) => {
-    const payload = { ...editData };
-    await updateQuestion(id, payload);
-    if (editImage) {
-      // image update not supported in API yet
+    try {
+      const { data } = await fetchQuestions();
+      setQuestions(data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error loading questions');
     }
-    setEditId(null);
-    setEditData({});
-    setEditImage(null);
-    load();
   };
 
+  // Create a new trivia question
+  const handleCreate = async () => {
+    try {
+      const formData = new FormData();
+      formData.append('title', newQ.title);
+      formData.append('text', newQ.text);
+      formData.append('options', newQ.options);
+      formData.append('correctAnswer', newQ.correctAnswer);
+      formData.append('notes', newQ.notes);
+      if (newImage) formData.append('image', newImage);
+      await createQuestion(formData);
+      setNewQ({ title: '', text: '', options: '', correctAnswer: '', notes: '' });
+      setNewImage(null);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error creating question');
+    }
+  };
+
+  // Persist edits to an existing question
+  const handleSave = async (id) => {
+    try {
+      const payload = { ...editData };
+      await updateQuestion(id, payload);
+      if (editImage) {
+        // image update not supported in API yet
+      }
+      setEditId(null);
+      setEditData({});
+      setEditImage(null);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error updating question');
+    }
+  };
+
+  // Delete a question
   const handleDelete = async (id) => {
-    await deleteQuestion(id);
-    load();
+    try {
+      await deleteQuestion(id);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error deleting question');
+    }
   };
 
   return (

--- a/client/src/pages/AdminSideQuestsPage.js
+++ b/client/src/pages/AdminSideQuestsPage.js
@@ -24,46 +24,70 @@ export default function AdminSideQuestsPage() {
     load();
   }, []);
 
+  // Retrieve all side quests for display
   const load = async () => {
-    const { data } = await fetchSideQuestsAdmin();
-    setQuests(data);
-  };
-
-  const handleCreate = async () => {
-    const formData = new FormData();
-    formData.append('title', newQuest.title);
-    formData.append('text', newQuest.text);
-    if (newQuest.image) formData.append('image', newQuest.image);
-    if (newQuest.timeLimitSeconds)
-      formData.append('timeLimitSeconds', newQuest.timeLimitSeconds);
-    formData.append('useStopwatch', newQuest.useStopwatch ? 'true' : 'false');
-    await createSideQuestAdmin(formData);
-    setNewQuest({ title: '', text: '', timeLimitSeconds: '', useStopwatch: false, image: null });
-    load();
-  };
-
-  const handleSave = async (id) => {
-    // If a new image was selected send multipart data, otherwise plain JSON
-    let payload = editData;
-    if (editData.image) {
-      // build multipart form data when a new image file is present
-      const formData = new FormData();
-      formData.append('title', editData.title);
-      formData.append('text', editData.text);
-      formData.append('image', editData.image);
-      formData.append('timeLimitSeconds', editData.timeLimitSeconds);
-      formData.append('useStopwatch', editData.useStopwatch ? 'true' : 'false');
-      payload = formData;
+    try {
+      const { data } = await fetchSideQuestsAdmin();
+      setQuests(data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error loading side quests');
     }
-    await updateSideQuestAdmin(id, payload);
-    setEditId(null);
-    setEditData({});
-    load();
   };
 
+  // Create a new side quest entry
+  const handleCreate = async () => {
+    try {
+      const formData = new FormData();
+      formData.append('title', newQuest.title);
+      formData.append('text', newQuest.text);
+      if (newQuest.image) formData.append('image', newQuest.image);
+      if (newQuest.timeLimitSeconds)
+        formData.append('timeLimitSeconds', newQuest.timeLimitSeconds);
+      formData.append('useStopwatch', newQuest.useStopwatch ? 'true' : 'false');
+      await createSideQuestAdmin(formData);
+      setNewQuest({ title: '', text: '', timeLimitSeconds: '', useStopwatch: false, image: null });
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error creating side quest');
+    }
+  };
+
+  // Save updates to a quest
+  const handleSave = async (id) => {
+    try {
+      // If a new image was selected send multipart data, otherwise plain JSON
+      let payload = editData;
+      if (editData.image) {
+        // build multipart form data when a new image file is present
+        const formData = new FormData();
+        formData.append('title', editData.title);
+        formData.append('text', editData.text);
+        formData.append('image', editData.image);
+        formData.append('timeLimitSeconds', editData.timeLimitSeconds);
+        formData.append('useStopwatch', editData.useStopwatch ? 'true' : 'false');
+        payload = formData;
+      }
+      await updateSideQuestAdmin(id, payload);
+      setEditId(null);
+      setEditData({});
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error updating side quest');
+    }
+  };
+
+  // Delete a quest
   const handleDelete = async (id) => {
-    await deleteSideQuestAdmin(id);
-    load();
+    try {
+      await deleteSideQuestAdmin(id);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error deleting side quest');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add try/catch blocks and alerts across admin CRUD pages
- show friendly messages when API calls fail

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685a711f8b648328af5b8165e2f8e8aa