### PR TITLE
Fix login form to support team credentials

### DIFF
--- a/client/src/pages/LoginPage.js
+++ b/client/src/pages/LoginPage.js
@@ -4,22 +4,31 @@ import { login } from '../services/api';
 
 // Simple login form for existing players
 export default function LoginPage() {
-  // Track input values for first and last name
+  // Track input values for each field required by the API
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
+  // New API requires a team name and team password as well
+  const [teamName, setTeamName] = useState('');
+  const [teamPassword, setTeamPassword] = useState('');
   const navigate = useNavigate();
 
   // Submit credentials to the API and handle response
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      // Send names as username/password to the login endpoint
-      const { data } = await login({ username: firstName, password: lastName });
-      // Save JWT for authenticated requests
+      // Send credentials in the format expected by the backend
+      const { data } = await login({
+        firstName,
+        lastName,
+        teamName,
+        teamPassword
+      });
+      // Store the JWT so subsequent requests are authenticated
       localStorage.setItem('token', data.token);
-      // Redirect to the player dashboard after successful login
+      // Navigate to the main dashboard on success
       navigate('/dashboard');
     } catch (err) {
+      // Surface any server error messages to the user
       alert(err.response?.data?.message || 'Login failed');
     }
   };
@@ -29,6 +38,7 @@ export default function LoginPage() {
       <h2>Player Login</h2>
       {/* onSubmit triggers handleSubmit above */}
       <form onSubmit={handleSubmit}>
+        {/* First and last name are required */}
         <label>First Name:</label>
         <input
           type="text"
@@ -36,11 +46,27 @@ export default function LoginPage() {
           onChange={(e) => setFirstName(e.target.value)}
           required
         />
-        <label>Surname:</label>
+        <label>Last Name:</label>
         <input
-          type="password"
+          type="text"
           value={lastName}
           onChange={(e) => setLastName(e.target.value)}
+          required
+        />
+
+        {/* Team name and password authenticate the player with their team */}
+        <label>Team Name:</label>
+        <input
+          type="text"
+          value={teamName}
+          onChange={(e) => setTeamName(e.target.value)}
+          required
+        />
+        <label>Team Password:</label>
+        <input
+          type="password"
+          value={teamPassword}
+          onChange={(e) => setTeamPassword(e.target.value)}
           required
         />
         <button type="submit">Log In</button>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -30,7 +30,7 @@ export const onboard = (formData) =>
 export const fetchTeamsList = () => axios.get('/api/onboard/teams');
 
 // Player authentication
-// Posts first/last name credentials to obtain a JWT
+// Submit player and team credentials to receive a JWT
 export const login = (creds) => axios.post('/api/auth/login', creds);
 
 // Player endpoints


### PR DESCRIPTION
## Summary
- update login form to include team name and password
- clarify login API call documentation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a7b27826083288150da069986c4ad