### PR TITLE
Fix admin settings upload error

### DIFF
--- a/server/middleware/upload.js
+++ b/server/middleware/upload.js
@@ -2,12 +2,25 @@
 
 const multer = require('multer');
 const path = require('path');
+const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
+
+// Absolute path to the uploads directory within the server folder
+const uploadDir = path.join(__dirname, '..', 'uploads');
+
+// Ensure that the uploads directory exists before any files are written.
+// Without this check, multer would throw an ENOENT error the first time an
+// admin tries to upload a logo or favicon because the directory hasn't been
+// created yet on fresh installs.
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir);
+}
 
 // Store uploads in the “uploads/” folder with a random UUID filename
 const storage = multer.diskStorage({
+  // Use the uploads directory defined above
   destination: (req, file, cb) => {
-    cb(null, 'uploads');
+    cb(null, uploadDir);
   },
   filename: (req, file, cb) => {
     const uniqueName = uuidv4() + path.extname(file.originalname);


### PR DESCRIPTION
## Summary
- ensure `server/uploads` directory exists before handling uploads

## Testing
- `npm test --silent` (no tests)
- `npm test --silent` in `server` (no tests)

------
https://chatgpt.com/codex/tasks/task_e_685a7b4dc16483289afa08e7713beb39