### PR TITLE
Add admin teams CRUD page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,6 +16,7 @@ import AdminCluesPage from './pages/AdminCluesPage';
 import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
 import AdminPlayersPage from './pages/AdminPlayersPage';
+import AdminTeamsPage from './pages/AdminTeamsPage';
 import AdminSettingsPage from './pages/AdminSettingsPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
@@ -155,6 +156,14 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminPlayersPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/teams"
+                element={
+                  <AdminRoute>
+                    <AdminTeamsPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -49,6 +49,7 @@ export default function Sidebar() {
           {renderLink('/admin/questions', 'Questions')}
           {renderLink('/admin/sidequests', 'Side Quests')}
           {renderLink('/admin/players', 'Players')}
+          {renderLink('/admin/teams', 'Teams')}
           {renderLink('/admin/settings', 'Settings')}
         </>
       )}

--- a/client/src/pages/AdminTeamsPage.js
+++ b/client/src/pages/AdminTeamsPage.js
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { fetchTeamsAdmin, createTeamAdmin, updateTeamAdmin, deleteTeamAdmin } from '../services/api';
+
+// Admin table for managing teams
+export default function AdminTeamsPage() {
+  const [teams, setTeams] = useState([]); // list of teams from the API
+  const [newTeam, setNewTeam] = useState({ name: '', password: '' });
+  const [editId, setEditId] = useState(null); // id of team being edited
+  const [editData, setEditData] = useState({}); // form state for edit row
+
+  // Load the list of teams on mount
+  useEffect(() => {
+    load();
+  }, []);
+
+  // Fetch all teams for display in the table
+  const load = async () => {
+    try {
+      const { data } = await fetchTeamsAdmin();
+      setTeams(data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error loading teams');
+    }
+  };
+
+  // Create a new team with name and password
+  const handleCreate = async () => {
+    try {
+      await createTeamAdmin(newTeam);
+      setNewTeam({ name: '', password: '' });
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error creating team');
+    }
+  };
+
+  // Save edits to an existing team
+  const handleSave = async (id) => {
+    try {
+      await updateTeamAdmin(id, editData);
+      setEditId(null);
+      setEditData({});
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error updating team');
+    }
+  };
+
+  // Delete a team by ID
+  const handleDelete = async (id) => {
+    try {
+      await deleteTeamAdmin(id);
+      load();
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error deleting team');
+    }
+  };
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>Teams</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Leader</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {teams.map((t) => (
+            <tr key={t._id}>
+              {editId === t._id ? (
+                <>
+                  <td>
+                    <input
+                      value={editData.name}
+                      onChange={(e) => setEditData({ ...editData, name: e.target.value })}
+                    />
+                  </td>
+                  <td>
+                    {t.leader ? t.leader.name : '-'}
+                  </td>
+                  <td>
+                    <button onClick={() => handleSave(t._id)}>Save</button>
+                    <button onClick={() => setEditId(null)}>Cancel</button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td>{t.name}</td>
+                  <td>{t.leader ? t.leader.name : '-'}</td>
+                  <td>
+                    <button onClick={() => { setEditId(t._id); setEditData({ name: t.name }); }}>Edit</button>
+                    <button onClick={() => handleDelete(t._id)}>Delete</button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+          <tr>
+            <td>
+              <input
+                value={newTeam.name}
+                onChange={(e) => setNewTeam({ ...newTeam, name: e.target.value })}
+                placeholder="Name"
+              />
+            </td>
+            <td>-</td>
+            <td>
+              <input
+                type="password"
+                value={newTeam.password}
+                onChange={(e) => setNewTeam({ ...newTeam, password: e.target.value })}
+                placeholder="Password"
+              />
+              <button onClick={handleCreate}>Add</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -101,6 +101,13 @@ export const createPlayer = (data) => axios.post('/api/admin/players', data);
 export const updatePlayer = (id, data) => axios.put(`/api/admin/players/${id}`, data);
 export const deletePlayer = (id) => axios.delete(`/api/admin/players/${id}`);
 
+// Admin CRUD for teams
+export const fetchTeamsAdmin = () => axios.get('/api/admin/teams');
+export const createTeamAdmin = (data) => axios.post('/api/admin/teams', data);
+export const updateTeamAdmin = (id, data) =>
+  axios.put(`/api/admin/teams/${id}`, data);
+export const deleteTeamAdmin = (id) => axios.delete(`/api/admin/teams/${id}`);
+
 // Admin CRUD for questions
 export const fetchQuestions = () => axios.get('/api/admin/questions');
 // Image uploads require multipart/form-data


### PR DESCRIPTION
## Summary
- add admin page to manage teams
- wire up new routes in the client
- expose admin team API helpers
- update sidebar navigation

## Testing
- `npm test` (fails: Missing script)
- `cd server && npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_685a8a79ac088328a0abf3d4f313cebb