### PR TITLE
Add team player management

### DIFF
--- a/client/src/pages/AdminTeamsPage.js
+++ b/client/src/pages/AdminTeamsPage.js
@@ -1,12 +1,24 @@
 import React, { useEffect, useState } from 'react';
-import { fetchTeamsAdmin, createTeamAdmin, updateTeamAdmin, deleteTeamAdmin } from '../services/api';
+import {
+  fetchTeamsAdmin,
+  createTeamAdmin,
+  updateTeamAdmin,
+  deleteTeamAdmin,
+  fetchPlayersByTeam,
+  createPlayer,
+  deletePlayer
+} from '../services/api';
 
-// Admin table for managing teams
+// Admin table for managing teams. The expanded row lets an admin add or remove
+// players without leaving the page.
 export default function AdminTeamsPage() {
   const [teams, setTeams] = useState([]); // list of teams from the API
   const [newTeam, setNewTeam] = useState({ name: '', password: '' });
   const [editId, setEditId] = useState(null); // id of team being edited
   const [editData, setEditData] = useState({}); // form state for edit row
+  const [expandedId, setExpandedId] = useState(null); // team showing players
+  const [players, setPlayers] = useState([]); // players for expanded team
+  const [newPlayerName, setNewPlayerName] = useState('');
 
   // Load the list of teams on mount
   useEffect(() => {
@@ -60,6 +72,48 @@ export default function AdminTeamsPage() {
     }
   };
 
+  // Expand a row to show and manage the team's players
+  const handleExpand = async (id) => {
+    if (expandedId === id) {
+      setExpandedId(null);
+      setPlayers([]);
+      return;
+    }
+    setExpandedId(id);
+    try {
+      const res = await fetchPlayersByTeam(id);
+      setPlayers(res.data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error loading players');
+    }
+  };
+
+  // Add a new player linked to the currently expanded team
+  const handleAddPlayer = async () => {
+    try {
+      await createPlayer({ name: newPlayerName, team: expandedId });
+      setNewPlayerName('');
+      const res = await fetchPlayersByTeam(expandedId);
+      setPlayers(res.data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error adding player');
+    }
+  };
+
+  // Remove an existing player
+  const handleRemovePlayer = async (playerId) => {
+    try {
+      await deletePlayer(playerId);
+      const res = await fetchPlayersByTeam(expandedId);
+      setPlayers(res.data);
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Error deleting player');
+    }
+  };
+
   return (
     <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
       <h2>Teams</h2>
@@ -73,34 +127,59 @@ export default function AdminTeamsPage() {
         </thead>
         <tbody>
           {teams.map((t) => (
-            <tr key={t._id}>
-              {editId === t._id ? (
-                <>
-                  <td>
+            <React.Fragment key={t._id}>
+              <tr>
+                {editId === t._id ? (
+                  <>
+                    <td>
+                      <input
+                        value={editData.name}
+                        onChange={(e) => setEditData({ ...editData, name: e.target.value })}
+                      />
+                    </td>
+                    <td>{t.leader ? t.leader.name : '-'}</td>
+                    <td>
+                      <button onClick={() => handleSave(t._id)}>Save</button>
+                      <button onClick={() => setEditId(null)}>Cancel</button>
+                    </td>
+                  </>
+                ) : (
+                  <>
+                    <td>{t.name}</td>
+                    <td>{t.leader ? t.leader.name : '-'}</td>
+                    <td>
+                      <button onClick={() => handleExpand(t._id)}>
+                        {expandedId === t._id ? 'Hide' : 'Players'}
+                      </button>
+                      <button onClick={() => { setEditId(t._id); setEditData({ name: t.name }); }}>Edit</button>
+                      <button onClick={() => handleDelete(t._id)}>Delete</button>
+                    </td>
+                  </>
+                )}
+              </tr>
+              {expandedId === t._id && (
+                <tr>
+                  <td colSpan="3">
+                    {/* Existing players for this team */}
+                    <ul>
+                      {players.map((p) => (
+                        <li key={p._id}>
+                          {p.name}{' '}
+                          <button onClick={() => handleRemovePlayer(p._id)}>Remove</button>
+                        </li>
+                      ))}
+                    </ul>
+                    {/* Add a new player */}
                     <input
-                      value={editData.name}
-                      onChange={(e) => setEditData({ ...editData, name: e.target.value })}
+                      value={newPlayerName}
+                      onChange={(e) => setNewPlayerName(e.target.value)}
+                      placeholder="New player name"
                     />
+                    <button onClick={handleAddPlayer}>Add Player</button>
                   </td>
-                  <td>
-                    {t.leader ? t.leader.name : '-'}
-                  </td>
-                  <td>
-                    <button onClick={() => handleSave(t._id)}>Save</button>
-                    <button onClick={() => setEditId(null)}>Cancel</button>
-                  </td>
-                </>
-              ) : (
-                <>
-                  <td>{t.name}</td>
-                  <td>{t.leader ? t.leader.name : '-'}</td>
-                  <td>
-                    <button onClick={() => { setEditId(t._id); setEditData({ name: t.name }); }}>Edit</button>
-                    <button onClick={() => handleDelete(t._id)}>Delete</button>
-                  </td>
-                </>
+                </tr>
               )}
-            </tr>
+            </React.Fragment>
           ))}
           <tr>
             <td>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -98,6 +98,8 @@ export const deleteSideQuestAdmin = (id) => axios.delete(`/api/admin/sidequests/
 
 // Admin CRUD for players
 export const fetchPlayers = () => axios.get('/api/admin/players');
+export const fetchPlayersByTeam = (teamId) =>
+  axios.get(`/api/admin/players?team=${teamId}`);
 export const createPlayer = (data) => axios.post('/api/admin/players', data);
 export const updatePlayer = (id, data) => axios.put(`/api/admin/players/${id}`, data);
 export const deletePlayer = (id) => axios.delete(`/api/admin/players/${id}`);

--- a/server/controllers/teamController.js
+++ b/server/controllers/teamController.js
@@ -1,5 +1,6 @@
 const Team = require('../models/Team');
 const Media = require('../models/Media');
+const User = require('../models/User');
 const bcrypt = require('bcryptjs');
 
 exports.getTeam = async (req, res) => {
@@ -140,6 +141,8 @@ exports.deleteTeam = async (req, res) => {
       return res.status(403).json({ message: 'Not authorized' });
     }
 
+    // Removing the team should also remove any players linked to it
+    await User.deleteMany({ team: team._id });
     await Team.deleteOne({ _id: team._id });
     res.json({ message: 'Team deleted' });
   } catch (err) {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -41,10 +41,15 @@ exports.updateMe = async (req, res) => {
   }
 };
 
-// List all players (admin use)
+// List all players. Accepts optional ?team=<teamId> to filter by team
 exports.getAllPlayers = async (req, res) => {
   try {
-    const players = await User.find().populate('team', 'name');
+    const query = {};
+    // When a team id is provided, limit the search to that team
+    if (req.query.team) {
+      query.team = req.query.team;
+    }
+    const players = await User.find(query).populate('team', 'name');
     res.json(players);
   } catch (err) {
     console.error(err);
@@ -55,8 +60,15 @@ exports.getAllPlayers = async (req, res) => {
 // Create a new player attached to a team
 exports.createPlayer = async (req, res) => {
   try {
+    // Ensure a team id was provided
+    if (!req.body.team) {
+      return res.status(400).json({ message: 'Team is required' });
+    }
+
+    // Split name into first and last for convenience
     const [firstName, ...rest] = (req.body.name || '').trim().split(' ');
     const lastName = rest.join(' ');
+
     const player = await User.create({
       name: req.body.name,
       firstName,

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -7,6 +7,7 @@ const userSchema = new mongoose.Schema(
     firstName: { type: String, default: '' },
     lastName: { type: String, default: '' },
     photoUrl: { type: String, default: '' },            // e.g. "/uploads/uuid.jpg"
+    // Every player must be assigned to exactly one team
     team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team', required: true },
     isAdmin: { type: Boolean, default: false }          // true if this user created the team
   },


### PR DESCRIPTION
## Summary
- allow filtering players by team
- require team when creating players
- remove all players when a team is deleted
- expose `fetchPlayersByTeam` on the client API
- show/manage players directly from the admin teams page
- document that users belong to one team

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a91cc97bc83289741ce7e3259928d