### PR TITLE
Expose public roster endpoints

### DIFF
--- a/server/controllers/teamController.js
+++ b/server/controllers/teamController.js
@@ -13,6 +13,18 @@ exports.getTeam = async (req, res) => {
   }
 };
 
+// Return only public fields for all teams so the client can build a roster
+exports.getTeamsPublic = async (req, res) => {
+  try {
+    // Select safe fields only; _id is included by default
+    const teams = await Team.find().select('name photoUrl members colourScheme');
+    res.json(teams);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching teams' });
+  }
+};
+
 exports.updateColourScheme = async (req, res) => {
   const { primary, secondary } = req.body;
   try {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -57,6 +57,33 @@ exports.getAllPlayers = async (req, res) => {
   }
 };
 
+// Public list of players with their teams. Password fields are omitted
+exports.getPlayersPublic = async (req, res) => {
+  try {
+    const players = await User.find()
+      .select('-password')
+      .populate('team', 'name');
+    res.json(players);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching players' });
+  }
+};
+
+// Fetch a single player by ID for the profile page
+exports.getPlayerById = async (req, res) => {
+  try {
+    const player = await User.findById(req.params.id)
+      .select('-password')
+      .populate('team', 'name');
+    if (!player) return res.status(404).json({ message: 'Player not found' });
+    res.json(player);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching player' });
+  }
+};
+
 // Create a new player attached to a team
 exports.createPlayer = async (req, res) => {
   try {

--- a/server/routes/teams.js
+++ b/server/routes/teams.js
@@ -9,9 +9,13 @@ const {
   addMember,
   createTeam,
   updateTeam,
-  deleteTeam
+  deleteTeam,
+  getTeamsPublic
 } = require('../controllers/teamController');
 const Team = require('../models/Team');
+
+// Public list of teams with minimal details
+router.get('/', getTeamsPublic);
 
 router.get('/:teamId', auth, getTeam);
 // Only global admins may modify a team's colour scheme

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -2,9 +2,18 @@ const express = require('express');
 const router = express.Router();
 const auth = require('../middleware/auth');
 const upload = require('../middleware/upload');
-const { getMe, updateMe } = require('../controllers/userController');
+const {
+  getMe,
+  updateMe,
+  getPlayersPublic,
+  getPlayerById
+} = require('../controllers/userController');
 
 router.get('/me', auth, getMe);
 router.put('/me', auth, upload.fields([{ name: 'selfie', maxCount: 1 }]), updateMe);
+
+// Authenticated routes for listing players
+router.get('/', auth, getPlayersPublic);
+router.get('/:id', auth, getPlayerById);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- expose a read‐only list of teams and players
- allow fetching a single player by id
- hook new controller functions to team and user routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aad01e6e0832883b2a4f74cc2a477