### PR TITLE
Implement case-insensitive login

### DIFF
--- a/server/controllers/adminAuthController.js
+++ b/server/controllers/adminAuthController.js
@@ -7,12 +7,15 @@ const Admin = require('../models/Admin');
 // (Optional) register endpoint, used only if you want to create admins dynamically
 exports.registerAdmin = async (req, res) => {
   const { username, password } = req.body;
+  // Store admin credentials in lowercase to make them case-insensitive
+  const userLower = username.toLowerCase();
+  const passLower = password.toLowerCase();
   try {
-    if (await Admin.findOne({ username })) {
+    if (await Admin.findOne({ username: userLower })) {
       return res.status(400).json({ message: 'Admin already exists' });
     }
-    const hash = await bcrypt.hash(password, 10);
-    await Admin.create({ username, password: hash });
+    const hash = await bcrypt.hash(passLower, 10);
+    await Admin.create({ username: userLower, password: hash });
     return res.status(201).json({ message: 'Admin registered' });
   } catch (err) {
     console.error('Admin register error:', err);
@@ -23,12 +26,15 @@ exports.registerAdmin = async (req, res) => {
 // login endpoint
 exports.loginAdmin = async (req, res) => {
   const { username, password } = req.body;
+  // Normalize credentials for case-insensitive comparison
+  const userLower = username.toLowerCase();
+  const passLower = password.toLowerCase();
   try {
-    const admin = await Admin.findOne({ username });
+    const admin = await Admin.findOne({ username: userLower });
     if (!admin) {
       return res.status(400).json({ message: 'Invalid credentials' });
     }
-    const match = await bcrypt.compare(password, admin.password);
+    const match = await bcrypt.compare(passLower, admin.password);
     if (!match) {
       return res.status(400).json({ message: 'Invalid credentials' });
     }

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -12,6 +12,12 @@ exports.login = async (req, res) => {
   // Extract submitted credentials
   const { firstName, lastName } = req.body;
 
+  // Convert credentials to a consistent case so authentication is
+  // case-insensitive. Names are stored as originally entered, so we
+  // perform the comparison using RegExp with the 'i' flag.
+  const first = firstName?.trim();
+  const last = lastName?.trim();
+
   // 1) Basic validation of required fields
   // Only the player's name is needed to authenticate. This assumes names are
   // unique across all teams.
@@ -20,8 +26,11 @@ exports.login = async (req, res) => {
   }
 
   try {
-    // 2) Find the user by first and last name only
-    const user = await User.findOne({ firstName, lastName });
+    // 2) Find the user by name using a case-insensitive match
+    const user = await User.findOne({
+      firstName: new RegExp('^' + first + '$', 'i'),
+      lastName: new RegExp('^' + last + '$', 'i')
+    });
     if (!user) {
       return res.status(400).json({ message: 'Player not found' });
     }

--- a/server/server.js
+++ b/server/server.js
@@ -16,9 +16,10 @@ const Settings = require('./models/Settings');
 
 (async function seedAdmin() {
   try {
-    const username = process.env.ADMIN_USERNAME;
-    const password = process.env.ADMIN_PASSWORD;
+    const username = process.env.ADMIN_USERNAME?.toLowerCase();
+    const password = process.env.ADMIN_PASSWORD?.toLowerCase();
     if (username && password) {
+      // Store admin credentials in lowercase to keep them case-insensitive
       const exists = await Admin.findOne({ username });
       if (!exists) {
         const hash = await bcrypt.hash(password, 10);


### PR DESCRIPTION
## Summary
- normalize player names to support case-insensitive logins
- store admin credentials in lowercase and compare that way
- seed default admin using lowercase username and password

## Testing
- `npm test --prefix server` *(fails: Missing script)*
- `npm test --prefix client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c6ff675948328a62a4458c0e6ceb3