### PR TITLE
Add filters to rogues gallery

### DIFF
--- a/client/src/pages/RoguesGalleryPage.js
+++ b/client/src/pages/RoguesGalleryPage.js
@@ -6,6 +6,10 @@ export default function RoguesGalleryPage() {
   // Gallery items returned from the server
   const [media, setMedia] = useState([]);
   const [loading, setLoading] = useState(true);
+  // Selected filters for team, player and type
+  const [teamFilter, setTeamFilter] = useState('');
+  const [playerFilter, setPlayerFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
 
   useEffect(() => {
     // Load all uploaded media on mount
@@ -22,11 +26,77 @@ export default function RoguesGalleryPage() {
     load();
   }, []);
 
+  // Build dropdown options from the loaded media
+  const teamOptions = Array.from(
+    new Set(media.map((m) => m.team?.name).filter(Boolean))
+  );
+  const playerOptions = Array.from(
+    new Set(
+      media
+        .map((m) => m.uploadedBy?.name || m.uploadedBy?.username)
+        .filter(Boolean)
+    )
+  );
+
+  // Helper to categorize each media item for the type filter
+  const getCategory = (m) => {
+    if (m.type === 'profile') {
+      return m.tag === 'team_photo' ? 'usies' : 'selfies';
+    }
+    return 'tasks';
+  };
+
+  // Apply all selected filters
+  const filteredMedia = media.filter((m) => {
+    if (teamFilter && m.team?.name !== teamFilter) return false;
+    const uploaderName = m.uploadedBy?.name || m.uploadedBy?.username;
+    if (playerFilter && uploaderName !== playerFilter) return false;
+    if (typeFilter && getCategory(m) !== typeFilter) return false;
+    return true;
+  });
+
   if (loading) return <p>Loading…</p>;
 
   return (
     <div>
       <h2>Rogues Gallery</h2>
+      {/* Filter controls */}
+      <div style={{ marginBottom: '1rem' }}>
+        <select value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)}>
+          <option value="">All Teams</option>
+          {teamOptions.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>{' '}
+        <select
+          value={playerFilter}
+          onChange={(e) => setPlayerFilter(e.target.value)}
+        >
+          <option value="">All Players</option>
+          {playerOptions.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>{' '}
+        <select value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
+          <option value="">All Types</option>
+          <option value="selfies">Selfies</option>
+          <option value="usies">Usies</option>
+          <option value="tasks">Tasks</option>
+        </select>{' '}
+        <button
+          onClick={() => {
+            setTeamFilter('');
+            setPlayerFilter('');
+            setTypeFilter('');
+          }}
+        >
+          Show All
+        </button>
+      </div>
       <div
         style={{
           display: 'grid',
@@ -34,7 +104,7 @@ export default function RoguesGalleryPage() {
           gap: '1rem'
         }}
       >
-        {media.map((m) => (
+        {filteredMedia.map((m) => (
           <RogueItem key={m._id} media={m} />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add state and filter controls to RoguesGalleryPage
- compute unique team/player options from loaded media
- categorize media into selfies, usies and tasks
- include a 'Show All' button to clear filters

## Testing
- `npm test --silent` in `client` (no tests found)
- `npm test --silent` in `server` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_685c70d1054c83288146d9aa48b1d226