### PR TITLE
Fix admin theme refresh

### DIFF
--- a/client/src/context/ThemeContext.js
+++ b/client/src/context/ThemeContext.js
@@ -72,9 +72,21 @@ export const ThemeProvider = ({ children }) => {
     }
   }, [theme.faviconUrl]);
 
+  /**
+   * Update the currently applied theme colours locally. This does not persist
+   * to the server but ensures the UI updates immediately after the admin saves
+   * new colours.
+   */
+  const updateTheme = (primary, secondary) => {
+    setTheme((t) => ({ ...t, primary, secondary }));
+  };
+
   return (
-    // Expose current theme and a helper to re-fetch it after admin changes
-    <ThemeContext.Provider value={{ theme, refreshTheme: fetchTheme }}>
+    /* Expose the current theme plus helpers for fetching or locally updating
+       the values after an admin changes them */
+    <ThemeContext.Provider
+      value={{ theme, refreshTheme: fetchTheme, updateTheme }}
+    >
       {children}
     </ThemeContext.Provider>
   );

--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useContext } from 'react';
+// Pull in theme helpers so new colours update instantly
 import { ThemeContext } from '../context/ThemeContext';
 import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
 
 // Page allowing admin users to configure global game settings
 export default function AdminSettingsPage() {
-  const { refreshTheme } = useContext(ThemeContext);
+  const { refreshTheme, updateTheme } = useContext(ThemeContext);
   const [settings, setSettings] = useState({
     gameName: '',
     qrBaseUrl: '',
@@ -42,7 +43,9 @@ export default function AdminSettingsPage() {
 
       const { data } = await updateSettingsAdmin(formData);
       setSettings(data);
-      // Re-fetch theme so changes apply immediately across the app
+      // Immediately update the site theme with the new colours
+      updateTheme(data.theme.primary, data.theme.secondary);
+      // Re-fetch from the server so fonts, logos and other settings refresh
       refreshTheme();
       alert('Settings saved');
     } catch (err) {


### PR DESCRIPTION
## Summary
- allow ThemeContext to update theme colours immediately
- update admin settings page to apply colours instantly after saving

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` in `client` *(fails: react-scripts not found)*
- `npm test` in `server` *(fails: Missing script)*
- `npm run dev` in `server` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7195d0588328a571c0bcfdc4aa54