### PR TITLE
Store completed clues as ObjectIds

### DIFF
--- a/server/controllers/clueController.js
+++ b/server/controllers/clueController.js
@@ -114,6 +114,7 @@ exports.submitAnswer = async (req, res) => {
     }
 
     if (correct) {
+      // Record the completed clue by storing its ObjectId on the team
       team.completedClues.push(clue._id);
       team.currentClue = team.currentClue + 1;
       await team.save();

--- a/server/controllers/progressController.js
+++ b/server/controllers/progressController.js
@@ -8,6 +8,7 @@ exports.getScoreboard = async (req, res) => {
 
     // Map to a summary object for easier consumption by the client
     const board = teams.map(t => {
+      // completedClues holds ObjectIds, so length gives total solved clue count
       const clues = t.completedClues ? t.completedClues.length : 0;
       const quests = t.sideQuestProgress ? t.sideQuestProgress.length : 0;
       return {

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -17,9 +17,9 @@ const teamSchema = new mongoose.Schema(
     ],
     // You may keep any other fields you need (e.g. currentClue, colourScheme, etc.)
     currentClue: { type: Number, default: 1 },
-    // Track the numeric IDs of all solved clues
+    // Track ObjectIds of solved clues so we can reference them directly
     completedClues: {
-      type: [Number],
+      type: [mongoose.Schema.Types.ObjectId],
       default: []
     },
     colourScheme: {

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "migrate": "node scripts/migrateCompletedClues.js"
   },
   "dependencies": {
     "archiver": "^7.0.1",

--- a/server/scripts/migrateCompletedClues.js
+++ b/server/scripts/migrateCompletedClues.js
@@ -1,0 +1,40 @@
+const mongoose = require('mongoose');
+const connectDB = require('../config/db');
+const Team = require('../models/Team');
+const Clue = require('../models/Clue');
+
+/**
+ * Migration script to convert numeric completedClues values to ObjectIds.
+ * It maps numbers to clues ordered by creation date (1-based).
+ */
+(async function migrate() {
+  await connectDB();
+
+  // Build a map of clue number -> ObjectId
+  const clues = await Clue.find().sort({ createdAt: 1 });
+  const map = new Map();
+  clues.forEach((c, idx) => map.set(idx + 1, c._id));
+
+  const teams = await Team.find();
+  for (const team of teams) {
+    let changed = false;
+    team.completedClues = team.completedClues
+      .map((entry) => {
+        if (typeof entry === 'number') {
+          const id = map.get(entry);
+          if (id) {
+            changed = true;
+            return id;
+          }
+          return null; // drop invalid mapping
+        }
+        return entry;
+      })
+      .filter(Boolean);
+    if (changed) {
+      console.log(`Updating team ${team.name}`);
+      await team.save();
+    }
+  }
+  mongoose.disconnect();
+})();


### PR DESCRIPTION
## Summary
- keep clue IDs in the team schema as ObjectIds
- document ObjectId usage when saving solved clues
- clarify scoreboard logic regarding clue count
- provide a migration script for existing numeric data
- expose the migration via npm script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run migrate` *(fails: Cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_685c72580a38832889969997241e313c