### PR TITLE
Add admin gallery management page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,6 +17,7 @@ import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
 import AdminPlayersPage from './pages/AdminPlayersPage';
 import AdminTeamsPage from './pages/AdminTeamsPage';
+import AdminGalleryPage from './pages/AdminGalleryPage';
 import AdminSettingsPage from './pages/AdminSettingsPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
@@ -165,6 +166,14 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminTeamsPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/gallery"
+                element={
+                  <AdminRoute>
+                    <AdminGalleryPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -50,6 +50,7 @@ export default function Sidebar() {
           {renderLink('/admin/sidequests', 'Side Quests')}
           {renderLink('/admin/players', 'Players')}
           {renderLink('/admin/teams', 'Teams')}
+          {renderLink('/admin/gallery', 'Gallery')}
           {renderLink('/admin/settings', 'Settings')}
         </>
       )}

--- a/client/src/pages/AdminGalleryPage.js
+++ b/client/src/pages/AdminGalleryPage.js
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { fetchAdminGallery, updateMediaVisibility, fetchSettingsAdmin } from '../services/api';
+import RogueItem from '../components/RogueItem';
+
+// Admin view of all uploaded media with filtering and hide controls
+export default function AdminGalleryPage() {
+  const [media, setMedia] = useState([]);
+  const [placeholder, setPlaceholder] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [teamFilter, setTeamFilter] = useState('');
+  const [playerFilter, setPlayerFilter] = useState('');
+  const [typeFilter, setTypeFilter] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const gal = await fetchAdminGallery();
+        setMedia(gal.data);
+        const settings = await fetchSettingsAdmin();
+        setPlaceholder(settings.data.placeholderUrl || '');
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const teamOptions = Array.from(new Set(media.map((m) => m.team?.name).filter(Boolean)));
+  const playerOptions = Array.from(
+    new Set(media.map((m) => m.uploadedBy?.name || m.uploadedBy?.username).filter(Boolean))
+  );
+
+  const getCategory = (m) => {
+    if (m.type === 'profile') return m.tag === 'team_photo' ? 'usies' : 'selfies';
+    return 'tasks';
+  };
+
+  const filteredMedia = media.filter((m) => {
+    if (teamFilter && m.team?.name !== teamFilter) return false;
+    const uploaderName = m.uploadedBy?.name || m.uploadedBy?.username;
+    if (playerFilter && uploaderName !== playerFilter) return false;
+    if (typeFilter && getCategory(m) !== typeFilter) return false;
+    return true;
+  });
+
+  const toggleHidden = async (item) => {
+    try {
+      await updateMediaVisibility(item._id, !item.hidden);
+      setMedia((prev) => prev.map((m) => (m._id === item._id ? { ...m, hidden: !item.hidden } : m)));
+    } catch (err) {
+      console.error(err);
+      alert('Error updating media');
+    }
+  };
+
+  if (loading) return <p>Loading…</p>;
+
+  return (
+    <div>
+      <h2>Admin Gallery</h2>
+      <div style={{ marginBottom: '1rem' }}>
+        <select value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)}>
+          <option value="">All Teams</option>
+          {teamOptions.map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>{' '}
+        <select value={playerFilter} onChange={(e) => setPlayerFilter(e.target.value)}>
+          <option value="">All Players</option>
+          {playerOptions.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>{' '}
+        <select value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)}>
+          <option value="">All Types</option>
+          <option value="selfies">Selfies</option>
+          <option value="usies">Usies</option>
+          <option value="tasks">Tasks</option>
+        </select>{' '}
+        <button onClick={() => { setTeamFilter(''); setPlayerFilter(''); setTypeFilter(''); }}>
+          Show All
+        </button>
+      </div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))', gap: '1rem' }}>
+        {filteredMedia.map((m) => {
+          const display = { ...m, url: m.type === 'profile' && placeholder ? placeholder : m.url };
+          return (
+            <div key={m._id}>
+              <RogueItem media={display} />
+              <button onClick={() => toggleHidden(m)}>{m.hidden ? 'Unhide' : 'Hide'}</button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -12,11 +12,13 @@ export default function AdminSettingsPage() {
     theme: { primary: '#2196F3', secondary: '#FFC107' },
     fontFamily: 'Arial, sans-serif',
     logoUrl: '',
-    faviconUrl: ''
+    faviconUrl: '',
+    placeholderUrl: ''
   });
   // Local file objects for uploads
   const [logoFile, setLogoFile] = useState(null);
   const [faviconFile, setFaviconFile] = useState(null);
+  const [placeholderFile, setPlaceholderFile] = useState(null);
 
   // Load settings on mount
   useEffect(() => {
@@ -40,6 +42,7 @@ export default function AdminSettingsPage() {
       formData.append('theme', JSON.stringify(settings.theme));
       if (logoFile) formData.append('logo', logoFile);
       if (faviconFile) formData.append('favicon', faviconFile);
+      if (placeholderFile) formData.append('placeholder', placeholderFile);
 
       const { data } = await updateSettingsAdmin(formData);
       setSettings(data);
@@ -104,6 +107,11 @@ export default function AdminSettingsPage() {
       <input type="file" accept="image/*" onChange={(e) => setFaviconFile(e.target.files[0])} />
       {settings.faviconUrl && (
         <img src={settings.faviconUrl} alt="Current favicon" style={{ height: '16px', marginTop: '0.5rem' }} />
+      )}
+      <label>Gallery Placeholder:</label>
+      <input type="file" accept="image/*" onChange={(e) => setPlaceholderFile(e.target.files[0])} />
+      {settings.placeholderUrl && (
+        <img src={settings.placeholderUrl} alt="Current placeholder" style={{ height: '40px', marginTop: '0.5rem' }} />
       )}
 
       <button onClick={handleSave}>Save Changes</button>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -60,6 +60,11 @@ export const submitSideQuest = (id, data) =>
   });
 export const fetchRoguesGallery = () => axios.get('/api/roguery');
 
+// Admin gallery endpoints
+export const fetchAdminGallery = () => axios.get('/api/admin/gallery');
+export const updateMediaVisibility = (id, hidden) =>
+  axios.put(`/api/admin/gallery/${id}`, { hidden });
+
 
 // Admin endpoints
 export const adminRegister = (data) =>

--- a/server/controllers/rogueController.js
+++ b/server/controllers/rogueController.js
@@ -1,10 +1,30 @@
 const Media = require('../models/Media');
+const Settings = require('../models/Settings');
 
 exports.getAllMedia = async (req, res) => {
   try {
+    const placeholder = (await Settings.findOne())?.placeholderUrl;
+    const allMedia = await Media.find({ hidden: { $ne: true } })
+      .populate('uploadedBy', 'name username photoUrl')
+      .populate('team', 'name')
+      .populate('sideQuest', 'title')
+      .sort({ createdAt: -1 });
+    const sanitized = allMedia.map((m) => {
+      if (placeholder && m.type === 'profile') {
+        return { ...m.toObject(), url: placeholder };
+      }
+      return m;
+    });
+    res.json(sanitized);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching rogues gallery' });
+  }
+};
+
+exports.getAllMediaAdmin = async (req, res) => {
+  try {
     const allMedia = await Media.find()
-      // Populate uploader regardless of whether it's a User or Admin.
-      // We request both possible name fields so the client can display one.
       .populate('uploadedBy', 'name username photoUrl')
       .populate('team', 'name')
       .populate('sideQuest', 'title')
@@ -12,6 +32,21 @@ exports.getAllMedia = async (req, res) => {
     res.json(allMedia);
   } catch (err) {
     console.error(err);
-    res.status(500).json({ message: 'Error fetching rogues gallery' });
+    res.status(500).json({ message: 'Error fetching gallery' });
+  }
+};
+
+exports.updateMediaVisibility = async (req, res) => {
+  try {
+    const media = await Media.findByIdAndUpdate(
+      req.params.id,
+      { hidden: req.body.hidden },
+      { new: true }
+    );
+    if (!media) return res.status(404).json({ message: 'Media not found' });
+    res.json(media);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error updating media' });
   }
 };

--- a/server/controllers/settingsController.js
+++ b/server/controllers/settingsController.js
@@ -44,6 +44,10 @@ exports.updateSettings = async (req, res) => {
     if (req.files && req.files.favicon && req.files.favicon[0]) {
       updates.faviconUrl = '/uploads/' + req.files.favicon[0].filename;
     }
+    // Save uploaded placeholder image if provided
+    if (req.files && req.files.placeholder && req.files.placeholder[0]) {
+      updates.placeholderUrl = '/uploads/' + req.files.placeholder[0].filename;
+    }
 
     // upsert: create document if none exists
     const settings = await Settings.findOneAndUpdate({}, updates, {

--- a/server/models/Media.js
+++ b/server/models/Media.js
@@ -24,7 +24,9 @@ const mediaSchema = new mongoose.Schema(
       enum: ['profile', 'question', 'sideQuest', 'other'],
       default: 'other'
     },
-    tag: String
+    tag: String,
+    // When true the media is hidden from the public rogues gallery
+    hidden: { type: Boolean, default: false }
   },
   { timestamps: true }
 );

--- a/server/models/Settings.js
+++ b/server/models/Settings.js
@@ -10,6 +10,8 @@ const settingsSchema = new mongoose.Schema({
   // Optional logo and favicon paths served from /uploads
   logoUrl: String,
   faviconUrl: String,
+  // Placeholder image shown in the admin gallery instead of selfies/usies
+  placeholderUrl: String,
   // Global font family applied to the UI
   fontFamily: { type: String, default: 'Arial, sans-serif' }
 });

--- a/server/routes/admin/gallery.js
+++ b/server/routes/admin/gallery.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const adminAuth = require('../../middleware/adminAuth');
+const { getAllMediaAdmin, updateMediaVisibility } = require('../../controllers/rogueController');
+
+router.use(adminAuth);
+
+// GET /api/admin/gallery - list all media
+router.get('/', getAllMediaAdmin);
+
+// PUT /api/admin/gallery/:id - toggle hidden flag
+router.put('/:id', updateMediaVisibility);
+
+module.exports = router;

--- a/server/routes/admin/settings.js
+++ b/server/routes/admin/settings.js
@@ -13,7 +13,8 @@ router.put(
   '/',
   upload.fields([
     { name: 'logo', maxCount: 1 },
-    { name: 'favicon', maxCount: 1 }
+    { name: 'favicon', maxCount: 1 },
+    { name: 'placeholder', maxCount: 1 }
   ]),
   updateSettings
 );

--- a/server/server.js
+++ b/server/server.js
@@ -37,7 +37,7 @@ const Settings = require('./models/Settings');
   try {
     const count = await Settings.countDocuments();
     if (count === 0) {
-      await Settings.create({ fontFamily: 'Arial, sans-serif' });
+      await Settings.create({ fontFamily: 'Arial, sans-serif', placeholderUrl: '' });
       console.log('Seeded default settings');
     }
   } catch (err) {
@@ -82,6 +82,8 @@ app.use('/api/admin/scoreboard', require('./routes/admin/scoreboard'));
 app.use('/api/admin/settings', require('./routes/admin/settings'));
 // Route allowing admins to download all uploaded media as a zip
 app.use('/api/admin/media', require('./routes/admin/media'));
+// Admin gallery management
+app.use('/api/admin/gallery', require('./routes/admin/gallery'));
 
 // (If serving React in production, keep these lines. For local dev they can remain commented.)
 // app.use(express.static(path.join(__dirname, '../client/build')));


### PR DESCRIPTION
## Summary
- manage placeholder URL via settings
- allow marking media items as hidden and fetch them for admins
- expose `/api/admin/gallery` route for admins
- show admin gallery page with filtering and hide controls
- include placeholder image support on profile media

## Testing
- `npm run build` in `client`
- `node -c server.js`

------
https://chatgpt.com/codex/tasks/task_e_685c74521f4c8328aaf3b6116c8ff78a