### PR TITLE
Fix admin colour scheme revert

### DIFF
--- a/client/src/context/ThemeContext.js
+++ b/client/src/context/ThemeContext.js
@@ -16,7 +16,13 @@ export const ThemeProvider = ({ children }) => {
    * Fetch the current theme from the server and update state. Team colours
    * override the global settings if a player is logged in.
    */
-  const fetchTheme = async () => {
+  /**
+   * Retrieve the theme from the server. If `opts.ignoreTeam` is true the
+   * currently logged in player's team colours will not override the global
+   * settings. This is useful when an admin saves new colours and wants to
+   * preview the global scheme regardless of their team membership.
+   */
+  const fetchTheme = async (opts = {}) => {
     try {
       let th = {
         primary: '#2196F3',
@@ -32,7 +38,8 @@ export const ThemeProvider = ({ children }) => {
       if (globalRes.data.faviconUrl) th.faviconUrl = globalRes.data.faviconUrl;
 
       const token = localStorage.getItem('token');
-      if (token) {
+      // Only apply team-specific colours when not explicitly ignored
+      if (token && !opts.ignoreTeam) {
         const userRes = await axios.get('/api/users/me');
         const teamId = userRes.data.team._id;
         const teamRes = await axios.get(`/api/teams/${teamId}`);

--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -45,8 +45,10 @@ export default function AdminSettingsPage() {
       setSettings(data);
       // Immediately update the site theme with the new colours
       updateTheme(data.theme.primary, data.theme.secondary);
-      // Re-fetch from the server so fonts, logos and other settings refresh
-      refreshTheme();
+      // Re-fetch from the server so fonts, logos and other settings refresh.
+      // `ignoreTeam` prevents the admin's personal team colours from
+      // overriding the newly saved global theme during preview.
+      refreshTheme({ ignoreTeam: true });
       alert('Settings saved');
     } catch (err) {
       alert(err.response?.data?.message || 'Error saving settings');


### PR DESCRIPTION
## Summary
- support ignoring team scheme when refreshing theme
- prevent admin's team scheme from overriding global colours

## Testing
- `npm run build` in `client`
- `npm install` in `server`


------
https://chatgpt.com/codex/tasks/task_e_685c74e2f504832892c6b2f41aeff133