### PR TITLE
Add emoji reactions to rogues gallery

### DIFF
--- a/client/src/components/RogueItem.js
+++ b/client/src/components/RogueItem.js
@@ -1,11 +1,17 @@
 import React from 'react';
 
-function RogueItem({ media }) {
-  const { url, uploadedBy, team, sideQuest, type, createdAt } = media;
+function RogueItem({ media, onSelect }) {
+  const { url, uploadedBy, team, sideQuest, createdAt, reactions = [] } = media;
   const isVideo = url.match(/\.(mp4|mov|avi)$/i);
 
+  // Tally how many times each emoji was used
+  const counts = reactions.reduce((acc, r) => {
+    acc[r.emoji] = (acc[r.emoji] || 0) + 1;
+    return acc;
+  }, {});
+
   return (
-    <div className="card">
+    <div className="card" onClick={() => onSelect && onSelect(media)}>
       {isVideo ? (
         <video width="100%" controls>
           <source src={url} />
@@ -25,6 +31,16 @@ function RogueItem({ media }) {
           </>
         )}
         <small style={{ color: '#666' }}>{new Date(createdAt).toLocaleString()}</small>
+        {/* Display reaction counts beside each emoji */}
+        {Object.keys(counts).length > 0 && (
+          <div style={{ marginTop: '0.5rem' }}>
+            {Object.entries(counts).map(([emo, c]) => (
+              <span key={emo} style={{ marginRight: '0.5rem' }}>
+                {emo} {c}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/RogueModal.js
+++ b/client/src/components/RogueModal.js
@@ -1,0 +1,71 @@
+import React from 'react';
+
+/**
+ * Display a full-screen overlay with the selected media item enlarged and
+ * a list of which players reacted with each emoji.
+ */
+export default function RogueModal({ media, onClose, onReact, emojiOptions }) {
+  if (!media) return null;
+  const isVideo = media.url.match(/\.(mp4|mov|avi)$/i);
+
+  // Group reactions by emoji so we can list the reacting players
+  const grouped = media.reactions.reduce((acc, r) => {
+    if (!acc[r.emoji]) acc[r.emoji] = [];
+    acc[r.emoji].push(r.user.name);
+    return acc;
+  }, {});
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.8)',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        zIndex: 1000
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: '#fff',
+          padding: '1rem',
+          borderRadius: '4px',
+          maxWidth: '90%',
+          maxHeight: '90%',
+          overflow: 'auto'
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {isVideo ? (
+          <video width="100%" controls src={media.url} />
+        ) : (
+          <img src={media.url} alt="Media" style={{ width: '100%' }} />
+        )}
+        <div style={{ marginTop: '1rem' }}>
+          {emojiOptions.map((emo) => (
+            <button
+              key={emo}
+              onClick={() => onReact(emo)}
+              style={{ fontSize: '1.5rem', marginRight: '0.5rem' }}
+            >
+              {emo}
+            </button>
+          ))}
+        </div>
+        <div style={{ marginTop: '1rem' }}>
+          {Object.keys(grouped).map((emo) => (
+            <div key={emo} style={{ marginBottom: '0.5rem' }}>
+              <strong>{emo}</strong>: {grouped[emo].join(', ')}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -59,6 +59,8 @@ export const submitSideQuest = (id, data) =>
     headers: { 'Content-Type': 'multipart/form-data' }
   });
 export const fetchRoguesGallery = () => axios.get('/api/roguery');
+export const reactToMedia = (id, emoji) =>
+  axios.post(`/api/roguery/${id}/react`, { emoji });
 
 
 // Admin endpoints

--- a/server/controllers/rogueController.js
+++ b/server/controllers/rogueController.js
@@ -8,10 +8,56 @@ exports.getAllMedia = async (req, res) => {
       .populate('uploadedBy', 'name username photoUrl')
       .populate('team', 'name')
       .populate('sideQuest', 'title')
+      // Include reacting players' names for display
+      .populate('reactions.user', 'name')
       .sort({ createdAt: -1 });
     res.json(allMedia);
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Error fetching rogues gallery' });
+  }
+};
+
+// Handle a player reacting to a media item with an emoji
+exports.addReaction = async (req, res) => {
+  const { id } = req.params;
+  const { emoji } = req.body;
+
+  // Emoji selection is required
+  if (!emoji) {
+    return res.status(400).json({ message: 'Emoji required' });
+  }
+
+  try {
+    const media = await Media.findById(id);
+    if (!media) return res.status(404).json({ message: 'Media not found' });
+
+    // Check if this user has already reacted
+    const existing = media.reactions.find(
+      (r) => r.user.toString() === req.user._id.toString()
+    );
+
+    if (existing) {
+      // Same emoji again removes the reaction
+      if (existing.emoji === emoji) {
+        media.reactions = media.reactions.filter(
+          (r) => r.user.toString() !== req.user._id.toString()
+        );
+      } else {
+        // Otherwise update to the new emoji
+        existing.emoji = emoji;
+      }
+    } else {
+      // Add a new reaction entry
+      media.reactions.push({ user: req.user._id, emoji });
+    }
+
+    await media.save();
+    await media.populate('reactions.user', 'name');
+
+    res.json(media);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error updating reaction' });
   }
 };

--- a/server/models/Media.js
+++ b/server/models/Media.js
@@ -24,7 +24,15 @@ const mediaSchema = new mongoose.Schema(
       enum: ['profile', 'question', 'sideQuest', 'other'],
       default: 'other'
     },
-    tag: String
+    tag: String,
+    // Track which users reacted with which emoji. Each entry stores the
+    // reacting player's ObjectId and the emoji string they selected.
+    reactions: [
+      {
+        user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+        emoji: String
+      }
+    ]
   },
   { timestamps: true }
 );

--- a/server/routes/roguery.js
+++ b/server/routes/roguery.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const router = express.Router();
-const { getAllMedia } = require('../controllers/rogueController');
+const auth = require('../middleware/auth');
+const { getAllMedia, addReaction } = require('../controllers/rogueController');
 
 router.get('/', getAllMedia);
+
+// Allow authenticated players to react to an image/video
+router.post('/:id/react', auth, addReaction);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- store per-user emoji reactions in `Media` documents
- allow players to react to media via new API endpoint
- show reaction counts on gallery items
- view reactions and react in a modal

## Testing
- `npm run build` in `client`
- `node server/server.js` *(fails: The `uri` parameter to `openUri()` must be a string)*

------
https://chatgpt.com/codex/tasks/task_e_685c764c44b0832883a059ed774ce85d