### PR TITLE
Add question and sidequest detail routes

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -7,6 +7,8 @@ import WelcomePage from './pages/WelcomePage';
 import SignupPage from './pages/SignupPage';
 import Dashboard from './pages/Dashboard';
 import QuestionPage from './pages/QuestionPage';
+import QuestionPlayPage from './pages/QuestionPlayPage';
+import SideQuestDetailPage from './pages/SideQuestDetailPage';
 import ProfilePage from './pages/ProfilePage';
 import SideQuestPage from './pages/SideQuestPage';
 import RoguesGalleryPage from './pages/RoguesGalleryPage';
@@ -75,6 +77,12 @@ export default function App() {
                 }
               />
               <Route
+                path="/question/:id"
+                element={
+                  <QuestionPlayPage />
+                }
+              />
+              <Route
                 path="/profile"
                 element={
                   <AuthRoute>
@@ -90,6 +98,7 @@ export default function App() {
                   </AuthRoute>
                 }
               />
+              <Route path="/sidequest/:id" element={<SideQuestDetailPage />} />
               <Route
                 path="/roguery"
                 element={

--- a/client/src/pages/QuestionPlayPage.js
+++ b/client/src/pages/QuestionPlayPage.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchQuestion } from '../services/api';
+
+// Display a single trivia question for players
+export default function QuestionPlayPage() {
+  const { id } = useParams();
+  const [question, setQuestion] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data } = await fetchQuestion(id);
+        setQuestion(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (id) load();
+  }, [id]);
+
+  if (loading) return <p>Loading question…</p>;
+  if (!question) return <p>Question not found.</p>;
+
+  return (
+    <div>
+      <h2>{question.title}</h2>
+      <div className="card">
+        <p>{question.text}</p>
+        {question.imageUrl && (
+          <img
+            src={question.imageUrl}
+            alt={question.title}
+            style={{ maxWidth: '100%', marginTop: '1rem' }}
+          />
+        )}
+        {question.options && question.options.length > 0 && (
+          <ul style={{ marginTop: '1rem' }}>
+            {question.options.map((o, idx) => (
+              <li key={idx}>{o}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/SideQuestDetailPage.js
+++ b/client/src/pages/SideQuestDetailPage.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchSideQuest, submitSideQuest } from '../services/api';
+import PhotoUploader from '../components/PhotoUploader';
+
+// Detailed view for a single side quest with upload option
+export default function SideQuestDetailPage() {
+  const { id } = useParams();
+  const [quest, setQuest] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data } = await fetchSideQuest(id);
+        setQuest(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (id) load();
+  }, [id]);
+
+  const handleUpload = async (formData) => {
+    try {
+      await submitSideQuest(id, formData);
+      alert('Submission received!');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Upload failed');
+    }
+  };
+
+  if (loading) return <p>Loading…</p>;
+  if (!quest) return <p>Side quest not found.</p>;
+
+  return (
+    <div>
+      <h2>{quest.title}</h2>
+      <div className="card">
+        <p>{quest.text}</p>
+        {quest.instructions && <p>{quest.instructions}</p>}
+        {quest.imageUrl && (
+          <img
+            src={quest.imageUrl}
+            alt={quest.title}
+            style={{ width: '100%', borderRadius: '4px', marginTop: '1rem' }}
+          />
+        )}
+        <div style={{ marginTop: '1rem' }}>
+          <PhotoUploader
+            label="Upload Proof"
+            requiredMediaType={quest.requiredMediaType}
+            onUpload={handleUpload}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -51,6 +51,8 @@ export const addTeamMember = (teamId, formData) =>
 export const fetchClue = (clueId) => axios.get(`/api/clues/${clueId}`);
 export const submitAnswer = (clueId, answer) =>
   axios.post(`/api/clues/${clueId}/answer`, { answer });
+export const fetchQuestion = (id) => axios.get(`/api/questions/${id}`);
+export const fetchSideQuest = (id) => axios.get(`/api/sidequests/${id}`);
 
 // Public/player side quest endpoints
 export const fetchSideQuests = () => axios.get('/api/sidequests/public');

--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -3,6 +3,7 @@ const Media = require('../models/Media');
 const QRCode = require('qrcode');
 const Team = require('../models/Team');
 const { getQrBase } = require('../utils/qr');
+const mongoose = require('mongoose');
 
 // Ensure a side quest has a QR code stored
 // Ensure the QR code for a side quest reflects the current base URL
@@ -104,6 +105,29 @@ exports.deleteSideQuest = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Error deleting side quest' });
+  }
+};
+
+// Retrieve a side quest by ID for public display
+exports.getSideQuest = async (req, res) => {
+  const { id } = req.params;
+
+  // Validate ObjectId first to avoid casting errors
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(404).json({ message: 'Side quest not found' });
+  }
+
+  try {
+    const sq = await SideQuest.findById(id);
+    if (!sq) {
+      return res.status(404).json({ message: 'Side quest not found' });
+    }
+    // Ensure QR codes remain current for scans
+    await ensureQrCode(sq);
+    res.json(sq);
+  } catch (err) {
+    console.error('Error fetching side quest:', err);
+    res.status(500).json({ message: 'Error fetching side quest' });
   }
 };
 

--- a/server/routes/question.js
+++ b/server/routes/question.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { getQuestion } = require('../controllers/questionController');
+
+// Public endpoint to fetch a single question by ID
+router.get('/questions/:id', getQuestion);
+
+module.exports = router;

--- a/server/routes/sidequest.js
+++ b/server/routes/sidequest.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { getSideQuest } = require('../controllers/sideQuestController');
+
+// Public endpoint to fetch a single side quest by ID
+router.get('/sidequests/:id', getSideQuest);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -60,6 +60,8 @@ app.use('/api/users', require('./routes/users'));
 app.use('/api/teams', require('./routes/teams'));
 app.use('/api/sidequests', require('./routes/sidequests'));
 app.use('/api/roguery', require('./routes/roguery'));
+app.use('/api', require('./routes/question'));
+app.use('/api', require('./routes/sidequest'));
 
 // Public settings route
 app.use('/api/settings', require('./routes/settings'));


### PR DESCRIPTION
## Summary
- create `getQuestion` and `getSideQuest` controller helpers
- create new public route files for accessing a single question or side quest
- expose these routes in `server.js`
- add matching API helpers and React pages
- update routing to new pages

## Testing
- `npm test` in `server` *(fails: Missing script)*
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c7686748c832888862bb182326c4c