### PR TITLE
Fix placeholder replacement

### DIFF
--- a/client/src/pages/AdminGalleryPage.js
+++ b/client/src/pages/AdminGalleryPage.js
@@ -85,7 +85,11 @@ export default function AdminGalleryPage() {
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))', gap: '1rem' }}>
         {filteredMedia.map((m) => {
-          const display = { ...m, url: m.type === 'profile' && placeholder ? placeholder : m.url };
+          // Only swap in the placeholder when a profile photo has been hidden
+          const display = {
+            ...m,
+            url: m.type === 'profile' && m.hidden && placeholder ? placeholder : m.url
+          };
           return (
             <div key={m._id}>
               <RogueItem media={display} />


### PR DESCRIPTION
## Summary
- ensure placeholder image only replaces hidden selfie/usie images in public gallery
- show placeholder in admin gallery only for hidden profile photos

## Testing
- `npm test` *(fails: missing package.json/test script)*
- `npm --prefix server test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c77fb01d48328882a5c042da3d7e1