### PR TITLE
Add emoji reactions to rogues gallery

### DIFF
--- a/client/src/components/RogueItem.js
+++ b/client/src/components/RogueItem.js
@@ -1,32 +1,106 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { addReaction, fetchReactions } from '../services/api';
+
+// Set of emojis available for players to react with
+const EMOJIS = ['👍', '😂', '😮', '😢', '❤️'];
 
 function RogueItem({ media }) {
-  const { url, uploadedBy, team, sideQuest, type, createdAt } = media;
+  const { url, uploadedBy, team, sideQuest, createdAt } = media;
   const isVideo = url.match(/\.(mp4|mov|avi)$/i);
+  const [show, setShow] = useState(false); // modal visibility
+  const [reactions, setReactions] = useState([]); // fetched reactions
+
+  // Fetch existing reactions when the modal is opened
+  useEffect(() => {
+    if (!show) return;
+    const load = async () => {
+      try {
+        const { data } = await fetchReactions(media._id);
+        setReactions(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [show, media._id]);
+
+  // Group reactions by emoji to simplify rendering
+  const grouped = reactions.reduce((acc, r) => {
+    if (!acc[r.emoji]) acc[r.emoji] = [];
+    acc[r.emoji].push(r.user.name);
+    return acc;
+  }, {});
+
+  // Handle the user selecting an emoji reaction
+  const handleReact = async (emoji) => {
+    try {
+      await addReaction(media._id, emoji);
+      const { data } = await fetchReactions(media._id);
+      setReactions(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   return (
-    <div className="card">
-      {isVideo ? (
-        <video width="100%" controls>
-          <source src={url} />
-          Your browser does not support the video tag.
-        </video>
-      ) : (
-        <img src={url} alt="Media" style={{ width: '100%', borderRadius: '4px' }} />
-      )}
-      <div style={{ marginTop: '0.5rem' }}>
-        {/* uploadedBy can be a User or Admin. Display whichever name field exists */}
-        <strong>By:</strong>{' '}
-        {uploadedBy?.name || uploadedBy?.username || 'Unknown'} <br />
-        <strong>Team:</strong> {team?.name || 'N/A'} <br />
-        {sideQuest && (
-          <>
-            <strong>Side Quest:</strong> {sideQuest.title} <br />
-          </>
+    <>
+      <div className="card" onClick={() => setShow(true)} style={{ cursor: 'pointer' }}>
+        {isVideo ? (
+          <video width="100%" controls>
+            <source src={url} />
+            Your browser does not support the video tag.
+          </video>
+        ) : (
+          <img src={url} alt="Media" style={{ width: '100%', borderRadius: '4px' }} />
         )}
-        <small style={{ color: '#666' }}>{new Date(createdAt).toLocaleString()}</small>
+        <div style={{ marginTop: '0.5rem' }}>
+          {/* uploadedBy can be a User or Admin. Display whichever name field exists */}
+          <strong>By:</strong>{' '}
+          {uploadedBy?.name || uploadedBy?.username || 'Unknown'} <br />
+          <strong>Team:</strong> {team?.name || 'N/A'} <br />
+          {sideQuest && (
+            <>
+              <strong>Side Quest:</strong> {sideQuest.title} <br />
+            </>
+          )}
+          <small style={{ color: '#666' }}>{new Date(createdAt).toLocaleString()}</small>
+        </div>
       </div>
-    </div>
+
+      {/* Modal displayed when an item is clicked */}
+      {show && (
+        <div className="modal-overlay" onClick={() => setShow(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            {isVideo ? (
+              <video controls style={{ maxWidth: '100%' }}>
+                <source src={url} />
+                Your browser does not support the video tag.
+              </video>
+            ) : (
+              <img src={url} alt="Media" style={{ maxWidth: '100%', borderRadius: '4px' }} />
+            )}
+            <div style={{ marginTop: '1rem' }}>
+              {EMOJIS.map((e) => (
+                <button
+                  key={e}
+                  onClick={() => handleReact(e)}
+                  style={{ fontSize: '1.5rem', marginRight: '0.5rem' }}
+                >
+                  {e} {grouped[e] ? grouped[e].length : ''}
+                </button>
+              ))}
+            </div>
+            <div style={{ marginTop: '1rem' }}>
+              {Object.entries(grouped).map(([emoji, names]) => (
+                <div key={emoji}>
+                  <strong>{emoji}</strong>: {names.join(', ')}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -65,6 +65,11 @@ export const submitSideQuest = (id, data) =>
     headers: { 'Content-Type': 'multipart/form-data' }
   });
 export const fetchRoguesGallery = () => axios.get('/api/roguery');
+// Emoji reactions on gallery items
+export const addReaction = (mediaId, emoji) =>
+  axios.post('/api/reactions', { mediaId, emoji });
+export const fetchReactions = (mediaId) =>
+  axios.get(`/api/reactions/${mediaId}`);
 
 // Admin gallery endpoints
 export const fetchAdminGallery = () => axios.get('/api/admin/gallery');

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -210,3 +210,26 @@ td {
     font-weight: bold;
   }
 }
+
+/* ───────────────── MODAL ───────────────── */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  max-width: 90%;
+  max-height: 90%;
+  overflow: auto;
+  border-radius: 4px;
+}

--- a/server/controllers/reactionController.js
+++ b/server/controllers/reactionController.js
@@ -1,0 +1,42 @@
+const Reaction = require('../models/Reaction');
+
+// Save or update the current player's reaction on a media item.
+exports.addReaction = async (req, res) => {
+  try {
+    const { mediaId, emoji } = req.body;
+    if (!mediaId || !emoji) {
+      return res.status(400).json({ message: 'mediaId and emoji are required' });
+    }
+
+    let reaction = await Reaction.findOne({
+      media: mediaId,
+      user: req.user._id
+    });
+
+    if (reaction) {
+      // Update the existing reaction with the new emoji
+      reaction.emoji = emoji;
+      await reaction.save();
+    } else {
+      // Create a new reaction if one doesn't exist yet
+      reaction = await Reaction.create({ media: mediaId, user: req.user._id, emoji });
+    }
+
+    const populated = await reaction.populate('user', 'name');
+    res.json(populated);
+  } catch (err) {
+    console.error('Error saving reaction:', err);
+    res.status(500).json({ message: 'Error saving reaction' });
+  }
+};
+
+// List all reactions for a given media item.
+exports.getReactions = async (req, res) => {
+  try {
+    const reactions = await Reaction.find({ media: req.params.mediaId }).populate('user', 'name');
+    res.json(reactions);
+  } catch (err) {
+    console.error('Error fetching reactions:', err);
+    res.status(500).json({ message: 'Error fetching reactions' });
+  }
+};

--- a/server/models/Reaction.js
+++ b/server/models/Reaction.js
@@ -1,0 +1,16 @@
+const mongoose = require('mongoose');
+
+// Records a player's reaction emoji on a rogues gallery media item.
+// A unique index on {media, user} ensures each player can react only once per item.
+const reactionSchema = new mongoose.Schema(
+  {
+    media: { type: mongoose.Schema.Types.ObjectId, ref: 'Media', required: true },
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    emoji: { type: String, required: true }
+  },
+  { timestamps: true }
+);
+
+reactionSchema.index({ media: 1, user: 1 }, { unique: true });
+
+module.exports = mongoose.model('Reaction', reactionSchema);

--- a/server/routes/reactions.js
+++ b/server/routes/reactions.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const { addReaction, getReactions } = require('../controllers/reactionController');
+
+router.use(auth);
+
+// POST /api/reactions - record the current player's emoji reaction
+router.post('/', addReaction);
+
+// GET /api/reactions/:mediaId - list reactions for a media item
+router.get('/:mediaId', getReactions);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -60,6 +60,8 @@ app.use('/api/users', require('./routes/users'));
 app.use('/api/teams', require('./routes/teams'));
 app.use('/api/sidequests', require('./routes/sidequests'));
 app.use('/api/roguery', require('./routes/roguery'));
+// Players can react to rogues gallery items with emojis
+app.use('/api/reactions', require('./routes/reactions'));
 app.use('/api', require('./routes/question'));
 app.use('/api', require('./routes/sidequest'));
 


### PR DESCRIPTION
## Summary
- add new Reaction schema and controller
- expose `/api/reactions` endpoints
- hook reactions route into Express app
- allow reacting to gallery items from the client
- display reactions in a modal when an item is clicked
- add basic modal styles

## Testing
- `npm test --silent` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_685d16acc70c8328a25e4519b18bcfca