### PR TITLE
Add gallery sorting and reactions

### DIFF
--- a/client/src/components/RogueItem.js
+++ b/client/src/components/RogueItem.js
@@ -5,7 +5,7 @@ import { addReaction, fetchReactions } from '../services/api';
 const EMOJIS = ['👍', '😂', '😮', '😢', '❤️'];
 
 function RogueItem({ media }) {
-  const { url, uploadedBy, team, sideQuest, createdAt } = media;
+  const { url, uploadedBy, team, sideQuest, createdAt, emojiCounts = {} } = media;
   const isVideo = url.match(/\.(mp4|mov|avi)$/i);
   const [show, setShow] = useState(false); // modal visibility
   const [reactions, setReactions] = useState([]); // fetched reactions
@@ -65,12 +65,25 @@ function RogueItem({ media }) {
           )}
           <small style={{ color: '#666' }}>{new Date(createdAt).toLocaleString()}</small>
         </div>
+        <div style={{ marginTop: '0.25rem' }}>
+          {EMOJIS.map((e) => (
+            <span key={e} style={{ marginRight: '0.5rem' }}>
+              {e} {emojiCounts[e] || 0}
+            </span>
+          ))}
+        </div>
       </div>
 
       {/* Modal displayed when an item is clicked */}
       {show && (
         <div className="modal-overlay" onClick={() => setShow(false)}>
           <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <button
+              onClick={() => setShow(false)}
+              style={{ position: 'absolute', top: 8, right: 8, fontSize: '1.5rem', background: 'none', border: 'none', cursor: 'pointer' }}
+            >
+              ×
+            </button>
             {isVideo ? (
               <video controls style={{ maxWidth: '100%' }}>
                 <source src={url} />

--- a/client/src/pages/RoguesGalleryPage.js
+++ b/client/src/pages/RoguesGalleryPage.js
@@ -6,16 +6,18 @@ export default function RoguesGalleryPage() {
   // Gallery items returned from the server
   const [media, setMedia] = useState([]);
   const [loading, setLoading] = useState(true);
+  // How gallery items should be sorted
+  const [sortOrder, setSortOrder] = useState('newest');
   // Selected filters for team, player and type
   const [teamFilter, setTeamFilter] = useState('');
   const [playerFilter, setPlayerFilter] = useState('');
   const [typeFilter, setTypeFilter] = useState('');
 
   useEffect(() => {
-    // Load all uploaded media on mount
+    // Load media whenever the sort order changes
     const load = async () => {
       try {
-        const { data } = await fetchRoguesGallery();
+        const { data } = await fetchRoguesGallery(sortOrder);
         setMedia(data);
       } catch (err) {
         console.error(err);
@@ -24,7 +26,7 @@ export default function RoguesGalleryPage() {
       }
     };
     load();
-  }, []);
+  }, [sortOrder]);
 
   // Build dropdown options from the loaded media
   const teamOptions = Array.from(
@@ -86,6 +88,11 @@ export default function RoguesGalleryPage() {
           <option value="selfies">Selfies</option>
           <option value="usies">Usies</option>
           <option value="tasks">Tasks</option>
+        </select>{' '}
+        <select value={sortOrder} onChange={(e) => setSortOrder(e.target.value)}>
+          <option value="newest">Newest</option>
+          <option value="hottest">Hottest</option>
+          <option value="best">Best</option>
         </select>{' '}
         <button
           onClick={() => {

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -64,7 +64,10 @@ export const submitSideQuest = (id, data) =>
   axios.post(`/api/sidequests/${id}/submit`, data, {
     headers: { 'Content-Type': 'multipart/form-data' }
   });
-export const fetchRoguesGallery = () => axios.get('/api/roguery');
+// Retrieve rogues gallery items with optional sorting.
+// sort can be 'newest', 'hottest' or 'best'.
+export const fetchRoguesGallery = (sort = 'newest') =>
+  axios.get(`/api/roguery?sort=${sort}`);
 // Emoji reactions on gallery items
 export const addReaction = (mediaId, emoji) =>
   axios.post('/api/reactions', { mediaId, emoji });

--- a/server/controllers/rogueController.js
+++ b/server/controllers/rogueController.js
@@ -1,37 +1,109 @@
 const Media = require('../models/Media');
 const Settings = require('../models/Settings');
+const Reaction = require('../models/Reaction');
 
 exports.getAllMedia = async (req, res) => {
   try {
+    // Sorting option: newest|best|hottest (defaults to newest)
+    const sort = req.query.sort || 'newest';
+
     // URL of the placeholder image, if one has been configured in the settings
     const placeholder = (await Settings.findOne())?.placeholderUrl;
 
-    // Load *all* media. Visibility rules are applied below so that hidden
-    // profile photos can be replaced with the placeholder rather than being
-    // filtered out entirely.
+    // Load all media irrespective of visibility. Hidden profile photos are
+    // replaced with the placeholder while hidden non-profile media are skipped.
     const allMedia = await Media.find()
       .populate('uploadedBy', 'name username photoUrl')
       .populate('team', 'name')
-      .populate('sideQuest', 'title')
-      .sort({ createdAt: -1 });
+      .populate('sideQuest', 'title');
 
-    // Build the final list respecting hidden flags:
-    //   - Non-profile media marked as hidden should not be returned
-    //   - Hidden profile photos are returned with the placeholder image
-    //   - All other media is returned as-is
+    // Pre-compute reaction totals and recent (last 15 minutes) counts for all
+    // media in one aggregation query.
+    const ids = allMedia.map((m) => m._id);
+    const fifteen = new Date(Date.now() - 15 * 60 * 1000);
+    const reactionAgg = await Reaction.aggregate([
+      { $match: { media: { $in: ids } } },
+      {
+        $group: {
+          _id: '$media',
+          total: { $sum: 1 },
+          recent: {
+            $sum: {
+              $cond: [{ $gte: ['$createdAt', fifteen] }, 1, 0]
+            }
+          }
+        }
+      }
+    ]);
+
+    // Per-emoji counts for displaying reaction breakdowns
+    const emojiAgg = await Reaction.aggregate([
+      { $match: { media: { $in: ids } } },
+      {
+        $group: {
+          _id: { media: '$media', emoji: '$emoji' },
+          count: { $sum: 1 }
+        }
+      }
+    ]);
+    const countMap = {};
+    for (const r of reactionAgg) {
+      countMap[r._id.toString()] = {
+        total: r.total,
+        recent: r.recent,
+        emojis: {}
+      };
+    }
+    for (const e of emojiAgg) {
+      const id = e._id.media.toString();
+      if (!countMap[id]) countMap[id] = { total: 0, recent: 0, emojis: {} };
+      countMap[id].emojis[e._id.emoji] = e.count;
+    }
+
+    // Build the final list respecting hidden flags and attach reaction counts
     const sanitized = [];
     for (const m of allMedia) {
       if (m.hidden) {
-        // Replace hidden profile photos with the placeholder if available.
         if (placeholder && m.type === 'profile') {
-          sanitized.push({ ...m.toObject(), url: placeholder });
+          sanitized.push({
+            ...m.toObject(),
+            url: placeholder,
+            totalReactions: countMap[m._id.toString()]?.total || 0,
+            recentReactions: countMap[m._id.toString()]?.recent || 0,
+            emojiCounts: countMap[m._id.toString()]?.emojis || {}
+          });
         }
-        // Non-profile media marked hidden are omitted entirely
-        continue;
+        continue; // skip hidden non-profile items entirely
       }
 
-      // Visible media are returned unchanged
-      sanitized.push(m);
+      const counts = countMap[m._id.toString()] || { total: 0, recent: 0, emojis: {} };
+      sanitized.push({
+        ...m.toObject(),
+        totalReactions: counts.total,
+        recentReactions: counts.recent,
+        emojiCounts: counts.emojis
+      });
+    }
+
+    // Apply sorting rules
+    if (sort === 'best') {
+      sanitized.sort(
+        (a, b) => b.totalReactions - a.totalReactions
+      );
+    } else if (sort === 'hottest') {
+      const anyRecent = sanitized.some((m) => m.recentReactions > 0);
+      sanitized.sort((a, b) => {
+        if (anyRecent) {
+          if (b.recentReactions !== a.recentReactions) {
+            return b.recentReactions - a.recentReactions;
+          }
+        }
+        // fall back to best ranking
+        return b.totalReactions - a.totalReactions;
+      });
+    } else {
+      // newest first by creation time
+      sanitized.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
     }
 
     res.json(sanitized);


### PR DESCRIPTION
## Summary
- display reaction counts under each thumbnail
- add close button on gallery media modal
- implement sort options newest/hottest/best
- expose reaction stats from server

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_685d1a818a708328b01069b4d753eb03