### PR TITLE
Require login for QR pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project contains a React client and an Express/MongoDB server for running a
 - Team colour schemes and profile management
 - Admin settings include a **master reset** to wipe all game data after typing
   `definitely` as confirmation
+- Scanning QR codes requires login; unauthenticated scans redirect to the sign-in page
 
 ## Player Onboarding and Login
 Players still enter only their first and last name, but a selfie must be

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -83,7 +83,9 @@ export default function App() {
               <Route
                 path="/question/:id"
                 element={
-                  <QuestionPlayPage />
+                  <AuthRoute>
+                    <QuestionPlayPage />
+                  </AuthRoute>
                 }
               />
               <Route
@@ -102,7 +104,14 @@ export default function App() {
                   </AuthRoute>
                 }
               />
-              <Route path="/sidequest/:id" element={<SideQuestDetailPage />} />
+              <Route
+                path="/sidequest/:id"
+                element={
+                  <AuthRoute>
+                    <SideQuestDetailPage />
+                  </AuthRoute>
+                }
+              />
               <Route
                 path="/roguery"
                 element={

--- a/server/routes/question.js
+++ b/server/routes/question.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const { getQuestion } = require('../controllers/questionController');
-const optionalAuth = require('../middleware/optionalAuth');
+const auth = require('../middleware/auth');
 
-// Public endpoint to fetch a single question by ID
-router.get('/questions/:id', optionalAuth, getQuestion);
+// Player endpoint to fetch a single question by ID
+// Requires authentication so scans are only recorded for logged in users
+router.get('/questions/:id', auth, getQuestion);
 
 module.exports = router;

--- a/server/routes/sidequest.js
+++ b/server/routes/sidequest.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const { getSideQuest } = require('../controllers/sideQuestController');
-const optionalAuth = require('../middleware/optionalAuth');
+const auth = require('../middleware/auth');
 
-// Public endpoint to fetch a single side quest by ID
-router.get('/sidequests/:id', optionalAuth, getSideQuest);
+// Player endpoint to fetch a single side quest by ID
+// Authentication required to prevent registering scans for anonymous users
+router.get('/sidequests/:id', auth, getSideQuest);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- enforce auth for QR code routes for sidequests and questions
- wrap corresponding React routes with auth guard
- mention login requirement for QR codes in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d4a9048d08328a0114828309782a2