### PR TITLE
Add global QR scanner button

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.3.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-qr-scanner": "^1.0.0-alpha.11",
         "react-router-dom": "^6.8.1",
         "react-scripts": "5.0.1",
         "uuid": "^9.0.0"
@@ -4597,6 +4598,28 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.19.3.tgz",
+      "integrity": "sha512-RUv5svewpDoD0ymXleOP8yVTO5BLkR0zn5coGC/Vs1671u0OBJ4xdtR8WVWf08OcvrieEMHdSfQY3ZKtqII/hg==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -15098,6 +15121,20 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
+    "node_modules/react-qr-scanner": {
+      "version": "1.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/react-qr-scanner/-/react-qr-scanner-1.0.0-alpha.11.tgz",
+      "integrity": "sha512-TdaygL+4U9iapskJgK5Ilb1Cw4wwzQ3bVpIfzzbrEsxPaEJzmjQ7VuMz8E9hBQGCU4Ee+YtgglE3byEtgtRpkA==",
+      "license": "ISC",
+      "dependencies": {
+        "@zxing/library": "^0.19.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -17356,6 +17393,15 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "license": "MIT"
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "axios": "^1.3.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-qr-scanner": "^1.0.0-alpha.11",
     "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
     "uuid": "^9.0.0"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -27,6 +27,7 @@ import AdminSettingsPage from './pages/AdminSettingsPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
+import QrScanButton from './components/QrScanButton';
 
 // Guard for regular users
 const AuthRoute = ({ children }) => {
@@ -236,6 +237,7 @@ export default function App() {
             </Routes>
           </div>
         </div>
+        <QrScanButton />
       </BrowserRouter>
     </div>
   );

--- a/client/src/components/QrScanButton.js
+++ b/client/src/components/QrScanButton.js
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import QrReader from 'react-qr-scanner';
+
+/**
+ * Floating button + modal for scanning QR codes.
+ * Appears bottom-right on all pages and opens the camera when clicked.
+ */
+export default function QrScanButton() {
+  const [open, setOpen] = useState(false); // show/hide scanner overlay
+  const navigate = useNavigate();
+
+  // Called each time the scanner decodes a QR code
+  const handleScan = (data) => {
+    if (!data) return; // ignore empty scans
+
+    // `react-qr-scanner` may return an object with a `text` field
+    const raw = typeof data === 'string' ? data : data.text || '';
+    if (!raw) return;
+    let path;
+    try {
+      const url = new URL(raw); // parse full URLs
+      path = url.pathname + url.search; // keep query string if present
+    } catch (err) {
+      // Already a relative path
+      path = raw;
+    }
+
+    setOpen(false); // close overlay
+    // Navigate to the scanned route; prefix with slash if needed
+    navigate(path.startsWith('/') ? path : `/${path}`);
+  };
+
+  // Log camera errors for debugging
+  const handleError = (err) => {
+    console.error('QR scan error:', err);
+  };
+
+  return (
+    <>
+      <button
+        className="qr-scan-button"
+        onClick={() => setOpen(true)}
+        aria-label="Scan QR Code"
+      >
+        &#128247;
+      </button>
+      {open && (
+        <div className="modal-overlay" onClick={() => setOpen(false)}>
+          {/* Stop propagation so clicking inside doesn't close */}
+          <div
+            className="modal-content"
+            onClick={(e) => e.stopPropagation()}
+            style={{ position: 'relative' }}
+          >
+            <button
+              onClick={() => setOpen(false)}
+              style={{
+                position: 'absolute',
+                top: 8,
+                right: 8,
+                background: 'none',
+                border: 'none',
+                fontSize: '1.5rem',
+                cursor: 'pointer'
+              }}
+              aria-label="Close scanner"
+            >
+              ×
+            </button>
+            <QrReader
+              delay={300}
+              onError={handleError}
+              onScan={handleScan}
+              style={{ width: '100%' }}
+            />
+            <p style={{ textAlign: 'center' }}>Align QR code within frame</p>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -233,3 +233,22 @@ td {
   overflow: auto;
   border-radius: 4px;
 }
+
+/* Floating QR scan button */
+.qr-scan-button {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  z-index: 1100;
+  background-color: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 56px;
+  height: 56px;
+  font-size: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- install **react-qr-scanner** to read QR codes
- add `QrScanButton` component that opens a camera modal
- style a floating action button in bottom-right
- render the scanner button in `App`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d4c98e6bc83288e5d562f7ee46b50