### PR TITLE
Fix QR scanner on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ npm start
 The client will automatically proxy requests to the server on port `5000`.
 
 Once both services are running you can visit `http://localhost:3000` to use the app.
+
+**Note:** The QR scanner requires camera access, which is only permitted in secure contexts. When testing on a mobile device, open the site over `https://` or via `localhost`; otherwise the browser will block camera access and scanning will fail.

--- a/client/src/components/QrScanButton.js
+++ b/client/src/components/QrScanButton.js
@@ -10,6 +10,14 @@ export default function QrScanButton() {
   const [open, setOpen] = useState(false); // show/hide scanner overlay
   const navigate = useNavigate();
 
+  // Check if the browser can access the camera. On mobile devices the page must
+  // be served over HTTPS (or from `localhost`) for `getUserMedia` to be
+  // available. Older/unsupported browsers will not have this API either.
+  const cameraAvailable =
+    typeof navigator !== 'undefined' &&
+    navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === 'function';
+
   // Called each time the scanner decodes a QR code
   const handleScan = (data) => {
     if (!data) return; // ignore empty scans
@@ -40,7 +48,16 @@ export default function QrScanButton() {
     <>
       <button
         className="qr-scan-button"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          if (cameraAvailable) {
+            setOpen(true);
+          } else {
+            // Show a simple alert when camera access is not possible
+            alert(
+              'Camera access is not available. Please use HTTPS or localhost.'
+            );
+          }
+        }}
         aria-label="Scan QR Code"
       >
         &#128247;
@@ -68,13 +85,23 @@ export default function QrScanButton() {
             >
               ×
             </button>
-            <QrReader
-              delay={300}
-              onError={handleError}
-              onScan={handleScan}
-              style={{ width: '100%' }}
-            />
-            <p style={{ textAlign: 'center' }}>Align QR code within frame</p>
+            {cameraAvailable ? (
+              <>
+                <QrReader
+                  delay={300}
+                  onError={handleError}
+                  onScan={handleScan}
+                  style={{ width: '100%' }}
+                />
+                <p style={{ textAlign: 'center' }}>
+                  Align QR code within frame
+                </p>
+              </>
+            ) : (
+              <p style={{ textAlign: 'center' }}>
+                Camera access is not available. Use HTTPS or localhost.
+              </p>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- handle missing `getUserMedia` when running on HTTP or unsupported devices
- show helpful alert when camera isn't accessible and render fallback message
- document that mobile scanning requires HTTPS or localhost

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d53cd2f5c8328aa0eceb26d75c486