### PR TITLE
Fix mobile QR scanner permission handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ npm start        # plain node
 ```
 Start the React client (from `client`):
 ```bash
-npm start
+# Use HTTPS so mobile browsers allow camera access
+HTTPS=true npm start
 ```
 The client will automatically proxy requests to the server on port `5000`.
 


### PR DESCRIPTION
## Summary
- add camera permission request flow before opening QR scanner
- show permission errors inside modal
- start React dev server over HTTPS to allow camera access

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5862d20c8328b6cbfa5912f1d605