### PR TITLE
Clarify HTTPS start options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Environment files
 /server/.env
+/client/.env
 
 # Uploads folder
 /server/uploads

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ npm start        # plain node
 Start the React client (from `client`):
 ```bash
 # Use HTTPS so mobile browsers allow camera access
+# Option 1: run with an environment variable
 HTTPS=true npm start
+
+# Option 2: create a `.env` file in `client/` containing:
+#   HTTPS=true
+# Then simply run:
+# npm start
 ```
 The client will automatically proxy requests to the server on port `5000`.
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+# Enables HTTPS for the development server so mobile devices can access the camera
+HTTPS=true


### PR DESCRIPTION
## Summary
- add example client environment file
- ignore local env file
- document env file option in README

## Testing
- `npm test` *(fails: could not find package.json)*
- `npm test` in `client` *(fails: missing script)*
- `npm test` in `server` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d6a95e9288328be773db1d5b164e3