### PR TITLE
Fix camera orientation for QR scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ The client will automatically proxy requests to the server on port `5000`.
 Once both services are running you can visit `http://localhost:3000` to use the app.
 
 **Note:** The QR scanner requires camera access, which is only permitted in secure contexts. When testing on a mobile device, open the site over `https://` or via `localhost`; otherwise the browser will block camera access and scanning will fail.
+By default the QR scanner opens the rear camera. This can be changed from the **Profile** page if your device chooses the wrong camera.

--- a/client/src/components/QrScanButton.js
+++ b/client/src/components/QrScanButton.js
@@ -11,6 +11,11 @@ export default function QrScanButton() {
   const [errorMsg, setErrorMsg] = useState(''); // display permission errors
   const navigate = useNavigate();
 
+  // Default to the rear camera, but allow users to override this
+  // preference by storing a value in localStorage.
+  const preferredFacing =
+    localStorage.getItem('cameraFacingMode') || 'rear';
+
   // Determine if the browser exposes `getUserMedia` at all. Modern browsers
   // only make this API available on secure origins (HTTPS or `localhost`).
   const cameraAvailable =
@@ -103,6 +108,9 @@ export default function QrScanButton() {
                   delay={300}
                   onError={handleError}
                   onScan={handleScan}
+                  // Use the rear camera by default; this value can be
+                  // changed via the user profile settings.
+                  facingMode={preferredFacing}
                   style={{ width: '100%' }}
                 />
                 <p style={{ textAlign: 'center' }}>Align QR code within frame</p>

--- a/client/src/pages/ProfilePage.js
+++ b/client/src/pages/ProfilePage.js
@@ -6,6 +6,16 @@ export default function ProfilePage() {
   const [user, setUser] = useState(null);
   const [newName, setNewName] = useState('');
   const [selfieFile, setSelfieFile] = useState(null);
+  // Persist the user's preferred camera for QR scanning.
+  const [cameraPref, setCameraPref] = useState(
+    localStorage.getItem('cameraFacingMode') || 'rear'
+  );
+
+  // Store the preference whenever it changes so the
+  // scanner component can read it from localStorage.
+  useEffect(() => {
+    localStorage.setItem('cameraFacingMode', cameraPref);
+  }, [cameraPref]);
 
   useEffect(() => {
     const load = async () => {
@@ -46,7 +56,20 @@ export default function ProfilePage() {
           <input value={newName} onChange={(e) => setNewName(e.target.value)} required />
 
           <label>Profile Picture:</label>
-          <ProfilePic avatarUrl={user.photoUrl} onFileSelect={(file) => setSelfieFile(file)} />
+          <ProfilePic
+            avatarUrl={user.photoUrl}
+            onFileSelect={(file) => setSelfieFile(file)}
+          />
+
+          <label>QR Scanner Camera:</label>
+          {/* Allows the user to control which camera opens when scanning */}
+          <select
+            value={cameraPref}
+            onChange={(e) => setCameraPref(e.target.value)}
+          >
+            <option value="rear">Rear (default)</option>
+            <option value="front">Front</option>
+          </select>
 
           <button type="submit">Save Changes</button>
         </form>


### PR DESCRIPTION
## Summary
- use rear camera by default when scanning QR codes
- allow users to choose which camera to use in the profile page
- document camera preference in the README

## Testing
- `npm test --silent` in both `client` and `server` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685d6d1c627883288a044844cff8442c