### PR TITLE
Add camera capture option for image uploads

### DIFF
--- a/client/src/components/ImageSelector.js
+++ b/client/src/components/ImageSelector.js
@@ -1,0 +1,47 @@
+import React, { useRef } from 'react';
+
+/**
+ * Presents buttons to capture a photo using the device camera or
+ * upload an existing image from disk. The selected file is returned
+ * via the onSelect callback.
+ */
+export default function ImageSelector({ onSelect }) {
+  // refs to hidden input elements so we can trigger them programmatically
+  const captureRef = useRef(null); // input for taking a new photo
+  const uploadRef = useRef(null);  // input for choosing an existing image
+
+  const handleChange = (e) => {
+    const file = e.target.files[0];
+    if (file && onSelect) {
+      onSelect(file);
+    }
+    // clear the value so the same file can be selected again if needed
+    e.target.value = '';
+  };
+
+  return (
+    <div style={{ margin: '0.5rem 0' }}>
+      {/* Hidden file input that opens the camera */}
+      <input
+        type="file"
+        accept="image/*"
+        capture="environment"
+        ref={captureRef}
+        style={{ display: 'none' }}
+        onChange={handleChange}
+      />
+      {/* Hidden file input for selecting from disk */}
+      <input
+        type="file"
+        accept="image/*"
+        ref={uploadRef}
+        style={{ display: 'none' }}
+        onChange={handleChange}
+      />
+      <button type="button" onClick={() => captureRef.current.click()}>Take Photo</button>
+      <button type="button" onClick={() => uploadRef.current.click()} style={{ marginLeft: '0.5rem' }}>
+        Upload Photo
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/PhotoUploader.js
+++ b/client/src/components/PhotoUploader.js
@@ -1,11 +1,14 @@
 import React, { useState } from 'react';
+import ImageSelector from './ImageSelector';
 
+// Widget allowing players to attach media to side quest submissions.
+// For photo quests we let the user either capture a new image or upload one.
 function PhotoUploader({ label, requiredMediaType, onUpload }) {
-  const [file, setFile] = useState(null);
-  const [preview, setPreview] = useState('');
+  const [file, setFile] = useState(null);   // selected File object
+  const [preview, setPreview] = useState(''); // preview URL or filename
 
-  const handleFileChange = (e) => {
-    const f = e.target.files[0];
+  // Reads the chosen file and sets up a preview
+  const handleFileSelect = (f) => {
     if (!f) return;
     setFile(f);
 
@@ -20,6 +23,7 @@ function PhotoUploader({ label, requiredMediaType, onUpload }) {
     }
   };
 
+  // Send the selected file to the parent component as FormData
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!file) return alert('Please select a file');
@@ -32,11 +36,17 @@ function PhotoUploader({ label, requiredMediaType, onUpload }) {
     <div className="card">
       <h3>{label}</h3>
       <form onSubmit={handleSubmit}>
-        <input
-          type="file"
-          accept={requiredMediaType === 'photo' ? 'image/*' : 'video/*'}
-          onChange={handleFileChange}
-        />
+        {requiredMediaType === 'photo' ? (
+          // Allow users to take a new photo or upload an existing one
+          <ImageSelector onSelect={handleFileSelect} />
+        ) : (
+          // For video quests we just need a regular file input
+          <input
+            type="file"
+            accept="video/*"
+            onChange={(e) => handleFileSelect(e.target.files[0])}
+          />
+        )}
         {preview && requiredMediaType === 'photo' && (
           <img
             src={preview}

--- a/client/src/components/ProfilePic.js
+++ b/client/src/components/ProfilePic.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
+import ImageSelector from './ImageSelector';
 
 export default function ProfilePic({ avatarUrl, onFileSelect }) {
   const [preview, setPreview] = useState(avatarUrl || '');
 
-  const handleFileChange = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
+  // When a file is chosen via ImageSelector, update preview and inform parent
+  const handleFileSelect = (file) => {
     onFileSelect(file);
     const reader = new FileReader();
     reader.onloadend = () => {
@@ -23,7 +23,8 @@ export default function ProfilePic({ avatarUrl, onFileSelect }) {
           style={{ width: '100px', height: '100px', borderRadius: '50%', objectFit: 'cover' }}
         />
       )}
-      <input type="file" accept="image/*" onChange={handleFileChange} />
+      {/* Use ImageSelector so the user can take or upload a photo */}
+      <ImageSelector onSelect={handleFileSelect} />
     </div>
   );
 }

--- a/client/src/pages/AdminCluesPage.js
+++ b/client/src/pages/AdminCluesPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import ImageSelector from '../components/ImageSelector';
 import {
   fetchClues,
   createClueAdmin,
@@ -120,13 +121,9 @@ export default function AdminCluesPage() {
                   </td>
                   <td>
                     {/* allow uploading a replacement image when editing */}
-                    <input
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) =>
-                        setEditData({ ...editData, image: e.target.files[0] })
-                      }
-                    />
+                    <ImageSelector onSelect={(file) =>
+                      setEditData({ ...editData, image: file })
+                    } />
                   </td>
                   <td>
                     <input
@@ -200,13 +197,9 @@ export default function AdminCluesPage() {
             </td>
             <td>
               {/* file input for the clue image */}
-              <input
-                type="file"
-                accept="image/*"
-                onChange={(e) =>
-                  setNewClue({ ...newClue, image: e.target.files[0] })
-                }
-              />
+              <ImageSelector onSelect={(file) =>
+                setNewClue({ ...newClue, image: file })
+              } />
             </td>
             <td>
               <input

--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import ImageSelector from '../components/ImageSelector';
 import {
   fetchQuestions,
   createQuestion,
@@ -217,11 +218,7 @@ export default function AdminQuestionsPage() {
             </td>
             <td>
               {/* optional question image */}
-              <input
-                type="file"
-                accept="image/*"
-                onChange={(e) => setNewImage(e.target.files[0])}
-              />
+              <ImageSelector onSelect={(file) => setNewImage(file)} />
             </td>
             <td>-</td>
             <td>

--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
+import ImageSelector from '../components/ImageSelector';
 // Pull in theme helpers so new colours update instantly
 import { ThemeContext } from '../context/ThemeContext';
 import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
@@ -101,17 +102,18 @@ export default function AdminSettingsPage() {
       </select>
 
       <label>Logo:</label>
-      <input type="file" accept="image/*" onChange={(e) => setLogoFile(e.target.files[0])} />
+      {/* Allow taking a new photo or uploading one for the logo */}
+      <ImageSelector onSelect={(file) => setLogoFile(file)} />
       {settings.logoUrl && (
         <img src={settings.logoUrl} alt="Current logo" style={{ height: '40px', marginTop: '0.5rem' }} />
       )}
       <label>Favicon:</label>
-      <input type="file" accept="image/*" onChange={(e) => setFaviconFile(e.target.files[0])} />
+      <ImageSelector onSelect={(file) => setFaviconFile(file)} />
       {settings.faviconUrl && (
         <img src={settings.faviconUrl} alt="Current favicon" style={{ height: '16px', marginTop: '0.5rem' }} />
       )}
       <label>Gallery Placeholder:</label>
-      <input type="file" accept="image/*" onChange={(e) => setPlaceholderFile(e.target.files[0])} />
+      <ImageSelector onSelect={(file) => setPlaceholderFile(file)} />
       {settings.placeholderUrl && (
         <img src={settings.placeholderUrl} alt="Current placeholder" style={{ height: '40px', marginTop: '0.5rem' }} />
       )}

--- a/client/src/pages/AdminSideQuestsPage.js
+++ b/client/src/pages/AdminSideQuestsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import ImageSelector from '../components/ImageSelector';
 import {
   fetchSideQuestsAdmin,
   createSideQuestAdmin,
@@ -126,14 +127,10 @@ export default function AdminSideQuestsPage() {
                     />
                   </td>
                   <td>
-                    {/* upload a new picture for the quest */}
-                    <input
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) =>
-                        setEditData({ ...editData, image: e.target.files[0] })
-                      }
-                    />
+                  {/* upload a new picture for the quest */}
+                  <ImageSelector onSelect={(file) =>
+                    setEditData({ ...editData, image: file })
+                  } />
                   </td>
                   <td>
                     <input
@@ -207,13 +204,9 @@ export default function AdminSideQuestsPage() {
             </td>
             <td>
               {/* optional quest illustration */}
-              <input
-                type="file"
-                accept="image/*"
-                onChange={(e) =>
-                  setNewQuest({ ...newQuest, image: e.target.files[0] })
-                }
-              />
+              <ImageSelector onSelect={(file) =>
+                setNewQuest({ ...newQuest, image: file })
+              } />
             </td>
             <td>
               <input


### PR DESCRIPTION
## Summary
- allow taking photos in addition to uploading images
- introduce `ImageSelector` component to encapsulate capture logic
- integrate image capture in profile pictures and quest media
- update all admin pages that accept images

## Testing
- `npm run build` in `client`
- `npm ci` in `server`
- `npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_685d6d67f3108328a5d555a2aefc4018