### PR TITLE
Add teams and players screens

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,6 +10,9 @@ import QuestionPage from './pages/QuestionPage';
 import QuestionPlayPage from './pages/QuestionPlayPage';
 import SideQuestDetailPage from './pages/SideQuestDetailPage';
 import ProfilePage from './pages/ProfilePage';
+import PlayerProfilePage from './pages/PlayerProfilePage';
+import PlayersPage from './pages/PlayersPage';
+import TeamsPage from './pages/TeamsPage';
 import SideQuestPage from './pages/SideQuestPage';
 import RoguesGalleryPage from './pages/RoguesGalleryPage';
 import InfoPage from './pages/InfoPage';
@@ -94,6 +97,30 @@ export default function App() {
                 element={
                   <AuthRoute>
                     <ProfilePage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/player/:id"
+                element={
+                  <AuthRoute>
+                    <PlayerProfilePage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/players"
+                element={
+                  <AuthRoute>
+                    <PlayersPage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/teams"
+                element={
+                  <AuthRoute>
+                    <TeamsPage />
                   </AuthRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -37,7 +37,9 @@ export default function Sidebar() {
           {renderLink('/sidequests', 'Side Quests')}
           {renderLink('/roguery', 'Gallery')}
           {renderLink('/scoreboard', 'Scoreboard')}
-          {renderLink('/profile', 'Profile')}
+          {renderLink('/players', 'Players')}
+          {renderLink('/teams', 'Teams')}
+          {renderLink('/profile', 'My Profile')}
         </>
       )}
 

--- a/client/src/pages/PlayerProfilePage.js
+++ b/client/src/pages/PlayerProfilePage.js
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchPlayerById } from '../services/api';
+
+// Read-only profile for any player
+export default function PlayerProfilePage() {
+  const { id } = useParams(); // player id from the route
+  const [player, setPlayer] = useState(null);
+
+  useEffect(() => {
+    // Load player data when id changes
+    const load = async () => {
+      try {
+        const { data } = await fetchPlayerById(id);
+        setPlayer(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (!player) return <p>Loading…</p>;
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>{player.name}</h2>
+      {player.photoUrl && (
+        <img
+          src={player.photoUrl}
+          alt={`${player.name} avatar`}
+          style={{ width: '150px', height: '150px', borderRadius: '50%', objectFit: 'cover' }}
+        />
+      )}
+      <p>Team: {player.team ? player.team.name : '-'}</p>
+    </div>
+  );
+}

--- a/client/src/pages/PlayersPage.js
+++ b/client/src/pages/PlayersPage.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchPlayersPublic } from '../services/api';
+
+// List all players with their team names
+export default function PlayersPage() {
+  const [players, setPlayers] = useState([]); // roster from API
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Load player list once on mount
+    const load = async () => {
+      try {
+        const { data } = await fetchPlayersPublic();
+        setPlayers(data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>Players</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Team</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((p) => (
+            <tr key={p._id}>
+              {/* Name links to the player's profile */}
+              <td data-label="Name">
+                <Link to={`/player/${p._id}`}>{p.name}</Link>
+              </td>
+              <td data-label="Team">{p.team?.name || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchTeamsPublic, fetchPlayersPublic } from '../services/api';
+
+// Display all teams with players listed under each
+export default function TeamsPage() {
+  const [teams, setTeams] = useState([]); // teams from API
+  const [players, setPlayers] = useState([]); // used to map players to teams
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Fetch both teams and players concurrently
+    const load = async () => {
+      try {
+        const [teamRes, playerRes] = await Promise.all([
+          fetchTeamsPublic(),
+          fetchPlayersPublic()
+        ]);
+        setTeams(teamRes.data);
+        setPlayers(playerRes.data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+
+  // Helper to list players belonging to a team
+  const playersForTeam = (teamId) =>
+    players.filter((p) => p.team && p.team._id === teamId);
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>Teams</h2>
+      {teams.map((team) => (
+        <div key={team._id} className="card" style={{ marginBottom: '1rem' }}>
+          <h3>{team.name}</h3>
+          {team.photoUrl && (
+            <img
+              src={team.photoUrl}
+              alt={`${team.name} photo`}
+              style={{ width: '100%', maxWidth: '300px', objectFit: 'cover' }}
+            />
+          )}
+          <ul>
+            {playersForTeam(team._id).map((p) => (
+              <li key={p._id}>
+                <Link to={`/player/${p._id}`}>{p.name}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -48,6 +48,11 @@ export const addTeamMember = (teamId, formData) =>
     headers: { 'Content-Type': 'multipart/form-data' }
   });
 
+// List all players for public roster screens
+export const fetchPlayersPublic = () => axios.get('/api/users');
+// Fetch an individual player's public profile
+export const fetchPlayerById = (id) => axios.get(`/api/users/${id}`);
+
 export const fetchClue = (clueId) => axios.get(`/api/clues/${clueId}`);
 export const submitAnswer = (clueId, answer) =>
   axios.post(`/api/clues/${clueId}/answer`, { answer });


### PR DESCRIPTION
## Summary
- add public API helpers for listing players
- create PlayersPage to show all players and their teams
- create TeamsPage to list teams with member links
- allow viewing any player's profile via PlayerProfilePage
- wire new pages into router and sidebar

## Testing
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_685d78d902108328aaadc57a301ee534