### PR TITLE
Add comment wall feature

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import QuestionPlayPage from './pages/QuestionPlayPage';
 import SideQuestDetailPage from './pages/SideQuestDetailPage';
 import ProfilePage from './pages/ProfilePage';
 import PlayerProfilePage from './pages/PlayerProfilePage';
+import TeamProfilePage from './pages/TeamProfilePage';
 import PlayersPage from './pages/PlayersPage';
 import TeamsPage from './pages/TeamsPage';
 import SideQuestPage from './pages/SideQuestPage';
@@ -105,6 +106,14 @@ export default function App() {
                 element={
                   <AuthRoute>
                     <PlayerProfilePage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/team/:id"
+                element={
+                  <AuthRoute>
+                    <TeamProfilePage />
                   </AuthRoute>
                 }
               />

--- a/client/src/components/Wall.js
+++ b/client/src/components/Wall.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import ImageSelector from './ImageSelector';
+import { fetchWall, postComment } from '../services/api';
+
+// Displays comments for a profile and allows posting new ones.
+// type must be either 'user' or 'team'.
+export default function Wall({ type, id }) {
+  const [comments, setComments] = useState([]);
+  const [text, setText] = useState('');
+  const [file, setFile] = useState(null);
+
+  // Load comments whenever type or id changes
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchWall(type, id);
+        setComments(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [type, id]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const data = new FormData();
+    if (text) data.append('content', text);
+    if (file) data.append('image', file);
+
+    try {
+      const res = await postComment(type, id, data);
+      // Prepend new comment to the list
+      setComments([res.data, ...comments]);
+      setText('');
+      setFile(null);
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error posting comment');
+    }
+  };
+
+  return (
+    <div className="card" style={{ marginTop: '1rem' }}>
+      <h3>Wall</h3>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Write a comment..."
+          rows={3}
+          style={{ width: '100%', marginBottom: '0.5rem' }}
+        />
+        <ImageSelector onSelect={(f) => setFile(f)} />
+        <button type="submit">Post</button>
+      </form>
+      <div>
+        {comments.map((c) => (
+          <div key={c._id} className="card" style={{ marginBottom: '0.5rem' }}>
+            <p>
+              <strong>{c.author.name}</strong>{' '}
+              <span style={{ fontSize: '0.8em' }}>
+                {new Date(c.createdAt).toLocaleString()}
+              </span>
+            </p>
+            {c.content && <p>{c.content}</p>}
+            {c.imageUrl && (
+              <img
+                src={c.imageUrl}
+                alt="wall"
+                style={{ maxWidth: '100%', borderRadius: '4px' }}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/PlayerProfilePage.js
+++ b/client/src/pages/PlayerProfilePage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { fetchPlayerById } from '../services/api';
+import Wall from '../components/Wall';
 
 // Read-only profile for any player
 export default function PlayerProfilePage() {
@@ -33,6 +34,7 @@ export default function PlayerProfilePage() {
         />
       )}
       <p>Team: {player.team ? player.team.name : '-'}</p>
+      <Wall type="user" id={id} />
     </div>
   );
 }

--- a/client/src/pages/TeamProfilePage.js
+++ b/client/src/pages/TeamProfilePage.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchTeam } from '../services/api';
+import Wall from '../components/Wall';
+
+// Displays a single team's details along with its comment wall
+export default function TeamProfilePage() {
+  const { id } = useParams();
+  const [team, setTeam] = useState(null);
+
+  // Load team info on mount and when id changes
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchTeam(id);
+        setTeam(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, [id]);
+
+  if (!team) return <p>Loading…</p>;
+
+  return (
+    <div className="card" style={{ padding: '1rem', margin: '1rem' }}>
+      <h2>{team.name}</h2>
+      {team.photoUrl && (
+        <img
+          src={team.photoUrl}
+          alt={`${team.name} photo`}
+          style={{ width: '100%', maxWidth: '300px', objectFit: 'cover' }}
+        />
+      )}
+      <Wall type="team" id={team._id} />
+    </div>
+  );
+}

--- a/client/src/pages/TeamsPage.js
+++ b/client/src/pages/TeamsPage.js
@@ -38,7 +38,9 @@ export default function TeamsPage() {
       <h2>Teams</h2>
       {teams.map((team) => (
         <div key={team._id} className="card" style={{ marginBottom: '1rem' }}>
-          <h3>{team.name}</h3>
+          <h3>
+            <Link to={`/team/${team._id}`}>{team.name}</Link>
+          </h3>
           {team.photoUrl && (
             <img
               src={team.photoUrl}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -79,6 +79,13 @@ export const addReaction = (mediaId, emoji) =>
 export const fetchReactions = (mediaId) =>
   axios.get(`/api/reactions/${mediaId}`);
 
+// Wall comments on player/team profiles
+export const fetchWall = (type, id) => axios.get(`/api/wall/${type}/${id}`);
+export const postComment = (type, id, data) =>
+  axios.post(`/api/wall/${type}/${id}`, data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+
 // Admin gallery endpoints
 export const fetchAdminGallery = () => axios.get('/api/admin/gallery');
 export const updateMediaVisibility = (id, hidden) =>

--- a/server/controllers/wallController.js
+++ b/server/controllers/wallController.js
@@ -1,0 +1,62 @@
+const Comment = require('../models/Comment');
+const Media = require('../models/Media');
+
+// Helper to map URL param to model name
+function modelFromType(type) {
+  return type === 'user' ? 'User' : type === 'team' ? 'Team' : null;
+}
+
+// List comments on a player or team wall
+exports.getWall = async (req, res) => {
+  const model = modelFromType(req.params.type);
+  if (!model) return res.status(400).json({ message: 'Invalid wall type' });
+
+  try {
+    const comments = await Comment.find({
+      target: req.params.id,
+      targetModel: model
+    })
+      .populate('author', 'name photoUrl')
+      .sort({ createdAt: -1 });
+    res.json(comments);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching comments' });
+  }
+};
+
+// Post a new comment with optional photo
+exports.postComment = async (req, res) => {
+  const model = modelFromType(req.params.type);
+  if (!model) return res.status(400).json({ message: 'Invalid wall type' });
+
+  try {
+    let imageUrl = '';
+    if (req.file) {
+      imageUrl = '/uploads/' + req.file.filename;
+      // Record uploaded photos in the Media collection for gallery use
+      await Media.create({
+        url: imageUrl,
+        uploadedBy: req.user._id,
+        uploadedByModel: 'User',
+        team: model === 'Team' ? req.params.id : req.user.team,
+        type: 'other',
+        tag: 'wall'
+      });
+    }
+
+    const comment = await Comment.create({
+      content: req.body.content || '',
+      imageUrl,
+      author: req.user._id,
+      target: req.params.id,
+      targetModel: model
+    });
+
+    const populated = await comment.populate('author', 'name photoUrl');
+    res.status(201).json(populated);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error posting comment' });
+  }
+};

--- a/server/models/Comment.js
+++ b/server/models/Comment.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+
+// Comments can be left on either a user or a team profile. We use a dynamic
+// reference via `refPath` so Mongoose knows which collection to populate when
+// retrieving the target document.
+const commentSchema = new mongoose.Schema(
+  {
+    content: String, // text body of the comment
+    imageUrl: String, // optional photo attachment path
+    author: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    target: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+      refPath: 'targetModel'
+    },
+    targetModel: {
+      type: String,
+      required: true,
+      enum: ['User', 'Team']
+    }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Comment', commentSchema);

--- a/server/routes/wall.js
+++ b/server/routes/wall.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const upload = require('../middleware/upload');
+const { getWall, postComment } = require('../controllers/wallController');
+
+router.use(auth);
+
+// List comments for a user or team
+router.get('/:type/:id', getWall);
+
+// Post a new comment with optional image
+router.post('/:type/:id', upload.single('image'), postComment);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -62,6 +62,8 @@ app.use('/api/sidequests', require('./routes/sidequests'));
 app.use('/api/roguery', require('./routes/roguery'));
 // Players can react to rogues gallery items with emojis
 app.use('/api/reactions', require('./routes/reactions'));
+// Comment walls for player and team profiles
+app.use('/api/wall', require('./routes/wall'));
 app.use('/api', require('./routes/question'));
 app.use('/api', require('./routes/sidequest'));
 // Player progress routes


### PR DESCRIPTION
## Summary
- add Comment model with dynamic reference to User or Team
- create API routes/controller for posting and retrieving wall comments
- expose `/api/wall` endpoints via Express server
- implement Wall component in frontend for displaying and posting comments
- add Team profile page and integrate wall into player profiles
- update API service and routing to support new pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d7b73fa348328baee7d3aeb1bdc97