### PR TITLE
Add delete option for media in admin gallery

### DIFF
--- a/client/src/pages/AdminGalleryPage.js
+++ b/client/src/pages/AdminGalleryPage.js
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { fetchAdminGallery, updateMediaVisibility, fetchSettingsAdmin } from '../services/api';
+import {
+  fetchAdminGallery,
+  updateMediaVisibility,
+  fetchSettingsAdmin,
+  deleteMediaAdmin
+} from '../services/api';
 import RogueItem from '../components/RogueItem';
 
 // Admin view of all uploaded media with filtering and hide controls
@@ -55,6 +60,17 @@ export default function AdminGalleryPage() {
     }
   };
 
+  const handleDelete = async (item) => {
+    if (!window.confirm('Delete this media item?')) return;
+    try {
+      await deleteMediaAdmin(item._id);
+      setMedia((prev) => prev.filter((m) => m._id !== item._id));
+    } catch (err) {
+      console.error(err);
+      alert('Error deleting media');
+    }
+  };
+
   if (loading) return <p>Loading…</p>;
 
   return (
@@ -93,7 +109,8 @@ export default function AdminGalleryPage() {
           return (
             <div key={m._id}>
               <RogueItem media={display} />
-              <button onClick={() => toggleHidden(m)}>{m.hidden ? 'Unhide' : 'Hide'}</button>
+              <button onClick={() => toggleHidden(m)}>{m.hidden ? 'Unhide' : 'Hide'}</button>{' '}
+              <button onClick={() => handleDelete(m)}>Delete</button>
             </div>
           );
         })}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -90,6 +90,8 @@ export const postComment = (type, id, data) =>
 export const fetchAdminGallery = () => axios.get('/api/admin/gallery');
 export const updateMediaVisibility = (id, hidden) =>
   axios.put(`/api/admin/gallery/${id}`, { hidden });
+export const deleteMediaAdmin = (id) =>
+  axios.delete(`/api/admin/gallery/${id}`);
 
 
 // Admin endpoints

--- a/server/routes/admin/gallery.js
+++ b/server/routes/admin/gallery.js
@@ -1,7 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const adminAuth = require('../../middleware/adminAuth');
-const { getAllMediaAdmin, updateMediaVisibility } = require('../../controllers/rogueController');
+const {
+  getAllMediaAdmin,
+  updateMediaVisibility,
+  deleteMedia
+} = require('../../controllers/rogueController');
 
 router.use(adminAuth);
 
@@ -10,5 +14,7 @@ router.get('/', getAllMediaAdmin);
 
 // PUT /api/admin/gallery/:id - toggle hidden flag
 router.put('/:id', updateMediaVisibility);
+// DELETE /api/admin/gallery/:id - remove a media item entirely
+router.delete('/:id', deleteMedia);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow deleting media on the server
- expose delete API endpoint
- add delete button to admin gallery UI

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_685db9d338b8832882b9ec9309d00ab6