### PR TITLE
Fix default camera for QR scanner

### DIFF
--- a/client/src/components/QrScanButton.js
+++ b/client/src/components/QrScanButton.js
@@ -11,10 +11,30 @@ export default function QrScanButton() {
   const [errorMsg, setErrorMsg] = useState(''); // display permission errors
   const navigate = useNavigate();
 
-  // Default to the rear camera, but allow users to override this
-  // preference by storing a value in localStorage.
-  const preferredFacing =
-    localStorage.getItem('cameraFacingMode') || 'rear';
+  // Helper to normalise any persisted value from older versions of the app.
+  const readStoredFacingMode = () => {
+    const stored = localStorage.getItem('cameraFacingMode');
+    if (stored === 'front' || stored === 'user') return 'user';
+    if (stored === 'rear' || stored === 'environment') return 'environment';
+    return 'environment'; // default to the outward facing camera
+  };
+
+  // Keep track of which camera should be used. We default to the rear camera
+  // (labelled "environment" by most browsers) but persist the user's choice so
+  // it is reused next time.
+  const [facingMode, setFacingMode] = useState(readStoredFacingMode);
+
+  // When multiple cameras are present choose the most likely rear-facing option
+  // based on device labels. This helper is used with the `chooseDeviceId` prop
+  // of `react-qr-scanner` to override its default camera selection logic.
+  const chooseDeviceId = (matching, all) => {
+    if (facingMode === 'environment') {
+      const rear = all.find((d) => /back|rear|environment/i.test(d.label));
+      return (rear || matching[matching.length - 1] || all[0])?.deviceId;
+    }
+    // For the user-facing camera fall back to the first matching device
+    return (matching[0] || all[0])?.deviceId;
+  };
 
   // Determine if the browser exposes `getUserMedia` at all. Modern browsers
   // only make this API available on secure origins (HTTPS or `localhost`).
@@ -54,6 +74,9 @@ export default function QrScanButton() {
       <button
         className="qr-scan-button"
         onClick={async () => {
+          // Reload the user's preferred camera in case it was changed via the
+          // profile page while this component remained mounted.
+          setFacingMode(readStoredFacingMode());
           if (!cameraAvailable) {
             alert('Camera access is not available. Use HTTPS or localhost.');
             return;
@@ -62,7 +85,7 @@ export default function QrScanButton() {
             // Request permission before opening the scanner so the browser
             // prompts the user to allow camera access on first use.
             const stream = await navigator.mediaDevices.getUserMedia({
-              video: true
+              video: { facingMode }
             });
             // Immediately stop the stream so `react-qr-scanner` can take over
             stream.getTracks().forEach((t) => t.stop());
@@ -70,6 +93,22 @@ export default function QrScanButton() {
             setOpen(true);
           } catch (err) {
             console.error('Camera permission error:', err);
+            // If the preferred camera fails (often due to unavailable rear
+            // camera on some devices), fall back to the user facing camera.
+            if (facingMode === 'environment') {
+              try {
+                await navigator.mediaDevices.getUserMedia({
+                  video: { facingMode: 'user' }
+                });
+                setFacingMode('user');
+                localStorage.setItem('cameraFacingMode', 'user');
+                setErrorMsg('');
+                setOpen(true);
+                return;
+              } catch (fallbackErr) {
+                console.error('Fallback camera error:', fallbackErr);
+              }
+            }
             setErrorMsg(
               'Unable to access camera. Please grant permission and refresh the page.'
             );
@@ -95,22 +134,47 @@ export default function QrScanButton() {
                 right: 8,
                 background: 'none',
                 border: 'none',
-                fontSize: '1.5rem',
-                cursor: 'pointer'
+                fontSize: '3rem',
+                cursor: 'pointer',
+                zIndex: 1010
               }}
               aria-label="Close scanner"
             >
               ×
             </button>
+            {/* Allow the user to swap between front and rear cameras */}
+            <button
+              onClick={() => {
+                const next = facingMode === 'environment' ? 'user' : 'environment';
+                setFacingMode(next);
+                localStorage.setItem('cameraFacingMode', next);
+              }}
+              style={{
+                position: 'absolute',
+                top: 8,
+                left: 8,
+                background: 'none',
+                border: 'none',
+                fontSize: '3rem',
+                cursor: 'pointer',
+                zIndex: 1010
+              }}
+              aria-label="Switch camera"
+            >
+              ↻
+            </button>
             {cameraAvailable ? (
               <>
                 <QrReader
+                  key={facingMode} // force re-mount when switching cameras
                   delay={300}
                   onError={handleError}
                   onScan={handleScan}
-                  // Use the rear camera by default; this value can be
-                  // changed via the user profile settings.
-                  facingMode={preferredFacing}
+                  // Pass `rear` or `front` as expected by the library while
+                  // maintaining the modern `environment`/`user` values
+                  // internally.
+                  facingMode={facingMode === 'environment' ? 'rear' : 'front'}
+                  chooseDeviceId={chooseDeviceId}
                   style={{ width: '100%' }}
                 />
                 <p style={{ textAlign: 'center' }}>Align QR code within frame</p>

--- a/client/src/pages/ProfilePage.js
+++ b/client/src/pages/ProfilePage.js
@@ -7,9 +7,13 @@ export default function ProfilePage() {
   const [newName, setNewName] = useState('');
   const [selfieFile, setSelfieFile] = useState(null);
   // Persist the user's preferred camera for QR scanning.
-  const [cameraPref, setCameraPref] = useState(
-    localStorage.getItem('cameraFacingMode') || 'rear'
-  );
+  const getCameraPref = () => {
+    const stored = localStorage.getItem('cameraFacingMode');
+    if (stored === 'front' || stored === 'user') return 'user';
+    if (stored === 'rear' || stored === 'environment') return 'environment';
+    return 'environment';
+  };
+  const [cameraPref, setCameraPref] = useState(getCameraPref);
 
   // Store the preference whenever it changes so the
   // scanner component can read it from localStorage.
@@ -67,8 +71,8 @@ export default function ProfilePage() {
             value={cameraPref}
             onChange={(e) => setCameraPref(e.target.value)}
           >
-            <option value="rear">Rear (default)</option>
-            <option value="front">Front</option>
+            <option value="environment">Rear (default)</option>
+            <option value="user">Front</option>
           </select>
 
           <button type="submit">Save Changes</button>


### PR DESCRIPTION
## Summary
- pick the rear camera using device labels when available
- map modern facingMode values to `rear`/`front` for `react-qr-scanner`
- enlarge and raise z-index of overlay buttons

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dba54a8ac8328adb6393ee2872a7d