### PR TITLE
Add team answer selection with cooldown

### DIFF
--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -14,7 +14,8 @@ export default function AdminSettingsPage() {
     fontFamily: 'Arial, sans-serif',
     logoUrl: '',
     faviconUrl: '',
-    placeholderUrl: ''
+    placeholderUrl: '',
+    questionAnswerCooldown: 0
   });
   // Local file objects for uploads
   const [logoFile, setLogoFile] = useState(null);
@@ -41,6 +42,7 @@ export default function AdminSettingsPage() {
       formData.append('qrBaseUrl', settings.qrBaseUrl);
       formData.append('fontFamily', settings.fontFamily);
       formData.append('theme', JSON.stringify(settings.theme));
+      formData.append('questionAnswerCooldown', settings.questionAnswerCooldown);
       if (logoFile) formData.append('logo', logoFile);
       if (faviconFile) formData.append('favicon', faviconFile);
       if (placeholderFile) formData.append('placeholder', placeholderFile);
@@ -66,6 +68,18 @@ export default function AdminSettingsPage() {
       <input value={settings.gameName} onChange={(e) => setSettings({ ...settings, gameName: e.target.value })} />
       <label>QR Base URL:</label>
       <input value={settings.qrBaseUrl} onChange={(e) => setSettings({ ...settings, qrBaseUrl: e.target.value })} />
+      <label>Answer Cooldown (minutes):</label>
+      <input
+        type="number"
+        min="0"
+        value={settings.questionAnswerCooldown}
+        onChange={(e) =>
+          setSettings({
+            ...settings,
+            questionAnswerCooldown: parseInt(e.target.value, 10)
+          })
+        }
+      />
 
       <h3>Appearance</h3>
       <label>Primary Colour:</label>

--- a/client/src/pages/QuestionPlayPage.js
+++ b/client/src/pages/QuestionPlayPage.js
@@ -1,18 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchQuestion } from '../services/api';
+import { fetchQuestion, submitQuestionAnswer } from '../services/api';
 
 // Display a single trivia question for players
 export default function QuestionPlayPage() {
   const { id } = useParams();
   const [question, setQuestion] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [answer, setAnswer] = useState('');
+  const [lockedUntil, setLockedUntil] = useState(null);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     const load = async () => {
       try {
         const { data } = await fetchQuestion(id);
         setQuestion(data);
+        setAnswer(data.selectedAnswer || '');
+        setLockedUntil(data.lockExpiresAt ? new Date(data.lockExpiresAt) : null);
       } catch (err) {
         console.error(err);
       } finally {
@@ -24,6 +29,22 @@ export default function QuestionPlayPage() {
 
   if (loading) return <p>Loading question…</p>;
   if (!question) return <p>Question not found.</p>;
+
+  const isLocked = lockedUntil && new Date() < new Date(lockedUntil);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (isLocked) return;
+    try {
+      setSaving(true);
+      const { data } = await submitQuestionAnswer(id, answer);
+      setLockedUntil(data.lockExpiresAt ? new Date(data.lockExpiresAt) : null);
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error saving answer');
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div>
@@ -38,11 +59,30 @@ export default function QuestionPlayPage() {
           />
         )}
         {question.options && question.options.length > 0 && (
-          <ul style={{ marginTop: '1rem' }}>
+          <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
             {question.options.map((o, idx) => (
-              <li key={idx}>{o}</li>
+              <div key={idx}>
+                <label>
+                  <input
+                    type="radio"
+                    value={o}
+                    checked={answer === o}
+                    onChange={() => setAnswer(o)}
+                    disabled={isLocked}
+                  />{' '}
+                  {o}
+                </label>
+              </div>
             ))}
-          </ul>
+            <button type="submit" disabled={isLocked || saving}>
+              {answer ? 'Update Answer' : 'Submit Answer'}
+            </button>
+            {isLocked && (
+              <p style={{ color: 'red' }}>
+                Answer locked until {new Date(lockedUntil).toLocaleTimeString()}
+              </p>
+            )}
+          </form>
         )}
       </div>
     </div>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -57,6 +57,8 @@ export const fetchClue = (clueId) => axios.get(`/api/clues/${clueId}`);
 export const submitAnswer = (clueId, answer) =>
   axios.post(`/api/clues/${clueId}/answer`, { answer });
 export const fetchQuestion = (id) => axios.get(`/api/questions/${id}`);
+export const submitQuestionAnswer = (id, answer) =>
+  axios.post(`/api/questions/${id}/answer`, { answer });
 export const fetchSideQuest = (id) => axios.get(`/api/sidequests/${id}`);
 
 // Retrieve all clues for the logged-in player. The list is ordered by creation

--- a/server/models/Settings.js
+++ b/server/models/Settings.js
@@ -17,7 +17,9 @@ const settingsSchema = new mongoose.Schema({
   // Multipliers used by the scoreboard calculation
   scorePerCorrect: { type: Number, default: 10 },
   scorePerSideQuest: { type: Number, default: 5 },
-  scorePerCreatedQuest: { type: Number, default: 20 }
+  scorePerCreatedQuest: { type: Number, default: 20 },
+  // Number of minutes teams must wait before changing a trivia answer
+  questionAnswerCooldown: { type: Number, default: 0 }
 });
 
 module.exports = mongoose.model('Settings', settingsSchema);

--- a/server/models/Team.js
+++ b/server/models/Team.js
@@ -36,6 +36,18 @@ const teamSchema = new mongoose.Schema(
         }
       ],
       default: []
+    },
+    // Persist each team's selected answers for trivia questions so the choice
+    // is shared across players and subject to cooldown restrictions.
+    questionAnswers: {
+      type: [
+        {
+          question: { type: mongoose.Schema.Types.ObjectId, ref: 'Question' },
+          answer: String,
+          updatedAt: Date
+        }
+      ],
+      default: []
     }
   },
   { timestamps: true }

--- a/server/routes/question.js
+++ b/server/routes/question.js
@@ -1,10 +1,13 @@
 const express = require('express');
 const router = express.Router();
-const { getQuestion } = require('../controllers/questionController');
+const { getQuestion, submitTeamAnswer } = require('../controllers/questionController');
 const auth = require('../middleware/auth');
 
 // Player endpoint to fetch a single question by ID
 // Requires authentication so scans are only recorded for logged in users
 router.get('/questions/:id', auth, getQuestion);
+
+// Record or update a team's answer for a question
+router.post('/questions/:id/answer', auth, submitTeamAnswer);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- track question answers per team in DB
- allow players to submit and lock answers for trivia questions
- expose cooldown setting in admin panel
- update client to show radio buttons for questions

## Testing
- `node -e "require('./server/models/Team.js');"` *(fails: Cannot find module 'mongoose')*

------
https://chatgpt.com/codex/tasks/task_e_685fbf1f4fc8832889f75fc8d224a1be