### PR TITLE
Improve mobile navbar

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -73,33 +73,33 @@ export default function Navbar() {
       <ul className="nav-right">
         {/* Admin links */}
         {!adminToken && (
-          <li>
+          <li className="hide-mobile">
             <Link to="/admin/login">Admin</Link>
           </li>
         )}
         {adminToken && (
-          <li>
+          <li className="hide-mobile">
             <Link to="/admin/dashboard">Admin Dashboard</Link>
           </li>
         )}
 
         {/* Player shortcut */}
         {token && (
-          <li>
+          <li className="hide-mobile">
             <Link to="/dashboard">My Dashboard</Link>
           </li>
         )}
 
         {/* Logout button if logged in as player or admin */}
         {(token || adminToken) && (
-          <li>
+          <li className="hide-mobile">
             <button onClick={handleLogout} className="btn-link">
               Log Out
             </button>
           </li>
         )}
         {token && avatarUrl && (
-          <li style={{ position: 'relative' }}>
+          <li className="nav-avatar" style={{ position: 'relative' }}>
             <button
               onClick={() => setShowMenu(!showMenu)}
               style={{ background: 'none', border: 'none', padding: 0 }}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -71,7 +71,7 @@ img {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   position: sticky;
   top: 0;
-  z-index: 100;
+  z-index: 1100; /* keep above sidebar on phones */
 }
 
 .navbar a,
@@ -101,6 +101,10 @@ img {
 @media (max-width: 600px) {
   .nav-right li {
     margin-left: 0.5rem;
+  }
+  /* hide secondary links on small screens to keep layout tidy */
+  .nav-right li.hide-mobile {
+    display: none;
   }
 }
 
@@ -214,7 +218,7 @@ form textarea {
     padding: 0.5rem;
   }
   .sidebar a {
-    font-size: 0.85rem;
+    font-size: 1rem; /* better legibility on small screens */
   }
 }
 /* Hamburger menu toggles the sidebar on phones */


### PR DESCRIPTION
## Summary
- hide extra nav items on small screens
- keep navbar above the sidebar
- enlarge sidebar text for readability

## Testing
- `npm test --prefix client` *(fails: Missing script)*
- `npm run build --prefix client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff9439ec08328969b8f6c55662af1