### PR TITLE
Add install prompt banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ HTTPS=true npm start
 ```
 The client will automatically proxy requests to the server on port `5000`.
 
-Once both services are running you can visit `http://localhost:3000` to use the app. Modern browsers will offer an "Add to Home Screen" prompt because the client is now a Progressive Web App. Installing it provides an app-like experience and offline access.
+Once both services are running you can visit `http://localhost:3000` to use the app. Modern browsers will offer an "Add to Home Screen" prompt because the client is now a Progressive Web App. The site also displays a small banner on mobile to remind users they can install the app for offline access.
 
 **Note:** The QR scanner requires camera access, which is only permitted in secure contexts. When testing on a mobile device, open the site over `https://` or via `localhost`; otherwise the browser will block camera access and scanning will fail.
 By default the QR scanner opens the rear camera. This can be changed from the **Profile** page if your device chooses the wrong camera.

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -33,6 +33,7 @@ import AdminSettingsPage from './pages/AdminSettingsPage';
 import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
 import QrScanButton from './components/QrScanButton';
+import InstallPrompt from './components/InstallPrompt';
 
 // Guard for regular users
 const AuthRoute = ({ children }) => {
@@ -282,6 +283,8 @@ export default function App() {
             </Routes>
           </div>
         </div>
+        {/* Floating utilities shown on all pages */}
+        <InstallPrompt />
         <QrScanButton />
       </BrowserRouter>
     </div>

--- a/client/src/components/InstallPrompt.js
+++ b/client/src/components/InstallPrompt.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * Display a custom install prompt for the Progressive Web App.
+ * The component listens for the `beforeinstallprompt` event and shows
+ * an install button when the browser allows adding the app to the
+ * home screen. iOS browsers do not emit this event so we display simple
+ * instructions instead.
+ */
+export default function InstallPrompt() {
+  const [deferred, setDeferred] = useState(null); // event saved for later
+  const [showPrompt, setShowPrompt] = useState(false); // toggle banner visibility
+  const [showIos, setShowIos] = useState(false); // whether to show iOS text
+
+  useEffect(() => {
+    // Handler for modern browsers (Chrome, Edge, etc.)
+    const onBeforeInstall = (e) => {
+      e.preventDefault();
+      setDeferred(e); // stash the event so it can be triggered later
+      setShowPrompt(true);
+    };
+    window.addEventListener('beforeinstallprompt', onBeforeInstall);
+
+    // Detect iOS devices which do not support the event
+    const isIos = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      window.navigator.standalone;
+    if (isIos && !isStandalone) {
+      setShowIos(true);
+      setShowPrompt(true);
+    }
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstall);
+    };
+  }, []);
+
+  // Trigger the browser's install prompt
+  const install = async () => {
+    if (!deferred) return;
+    deferred.prompt();
+    await deferred.userChoice; // wait for the user to respond
+    setDeferred(null);
+    setShowPrompt(false);
+  };
+
+  if (!showPrompt) return null;
+
+  return (
+    <div className="install-banner">
+      {showIos ? (
+        // iOS users must manually use the browser's Share menu
+        <span>Install this app via Share &gt; Add to Home Screen</span>
+      ) : (
+        <>
+          <span>Install this app for quick access</span>
+          <button onClick={install} style={{ marginLeft: '0.5rem' }}>
+            Install
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -381,3 +381,28 @@ tbody tr:nth-child(even) {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   transition: opacity 0.2s;
 }
+
+/* Prompt banner offering PWA installation */
+.install-banner {
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom, 0) + 1rem);
+  left: calc(env(safe-area-inset-left, 0) + 1rem);
+  z-index: 1100;
+  background-color: var(--primary-color);
+  color: #fff;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.install-banner button {
+  margin-left: 0.5rem;
+  background: #fff;
+  color: var(--primary-color);
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add InstallPrompt component that listens for PWA install events
- attach InstallPrompt in the main app layout
- style installation banner and add docs

## Testing
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860103837d08328b89d3ca91452eed6