### PR TITLE
Fix PWA install banner detection on iOS

### DIFF
--- a/client/src/components/InstallPrompt.js
+++ b/client/src/components/InstallPrompt.js
@@ -21,8 +21,12 @@ export default function InstallPrompt() {
     };
     window.addEventListener('beforeinstallprompt', onBeforeInstall);
 
-    // Detect iOS devices which do not support the event
-    const isIos = /iphone|ipad|ipod/i.test(window.navigator.userAgent);
+    // Detect iOS devices which do not support the event. Newer iPads use a
+    // desktop-class user agent string, so we also check for touch support when
+    // running on Mac platforms.
+    const isIos =
+      /iphone|ipad|ipod/i.test(window.navigator.userAgent) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
     const isStandalone =
       window.matchMedia('(display-mode: standalone)').matches ||
       window.navigator.standalone;


### PR DESCRIPTION
## Summary
- improve iOS detection so the PWA install banner shows on mobile devices like iPadOS

## Testing
- `npm install` in `client`
- `npm run build` in `client`
- `npm install` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68606658f35483289ad996a2af2180b8