### PR TITLE
Enable HTTPS by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,13 @@ npm start        # plain node
 ```
 Start the React client (from `client`):
 ```bash
-# Use HTTPS so mobile browsers allow camera access
-# Option 1: run with an environment variable
-HTTPS=true npm start
-
-# Option 2: create a `.env` file in `client/` containing:
-#   HTTPS=true
-# Then simply run:
-# npm start
+npm start
 ```
-The client will automatically proxy requests to the server on port `5000`.
+The `start` script automatically enables HTTPS via `cross-env` so mobile
+browsers can register the service worker. The client will proxy requests to the
+server on port `5000`.
 
-Once both services are running you can visit `http://localhost:3000` to use the app. Modern browsers will offer an "Add to Home Screen" prompt because the client is now a Progressive Web App. The site also displays a small banner on mobile to remind users they can install the app for offline access.
+Once both services are running you can visit `https://localhost:3000` to use the app. Modern browsers will offer an "Add to Home Screen" prompt because the client is now a Progressive Web App. The site also displays a small banner on mobile to remind users they can install the app for offline access.
 
 **Note:** The QR scanner requires camera access, which is only permitted in secure contexts. When testing on a mobile device, open the site over `https://` or via `localhost`; otherwise the browser will block camera access and scanning will fail.
 By default the QR scanner opens the rear camera. This can be changed from the **Profile** page if your device chooses the wrong camera.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,9 @@
         "react-router-dom": "^6.8.1",
         "react-scripts": "5.0.1",
         "uuid": "^9.0.0"
+      },
+      "devDependencies": {
+        "cross-env": "^7.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6293,6 +6296,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "uuid": "^9.0.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "cross-env HTTPS=true react-scripts start",
     "build": "react-scripts build"
   },
   "proxy": "http://localhost:5000",
@@ -27,5 +27,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary
- start the React client over HTTPS automatically using cross-env
- explain the HTTPS default in the README

## Testing
- `npm test` in `client` *(fails: Missing script)*
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6860e48f8fb0832889efd8e6b9f8d82a