### PR TITLE
Add notification model and utility

### DIFF
--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+
+// Notifications can be targeted at either a single user or an entire team.
+// Only one of `user` or `team` will be set for any given notification.
+const notificationSchema = new mongoose.Schema(
+  {
+    // Individual player recipient
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    // Team recipient
+    team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team' },
+    // Actor who triggered the notification. Mongoose uses `refPath` to determine
+    // whether this ObjectId references a User or Team document.
+    actor: {
+      type: mongoose.Schema.Types.ObjectId,
+      required: true,
+      refPath: 'actorModel'
+    },
+    actorModel: {
+      type: String,
+      required: true,
+      enum: ['User', 'Team']
+    },
+    message: { type: String, required: true }, // text shown to the recipient
+    link: { type: String, default: '' },       // optional URL for more details
+    read: { type: Boolean, default: false }    // whether the recipient has read it
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Notification', notificationSchema);

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -1,0 +1,37 @@
+const Notification = require('../models/Notification');
+
+/**
+ * Insert a new notification into the database.
+ * Only one of `user` or `team` should be specified.
+ *
+ * @param {Object} options
+ * @param {mongoose.ObjectId} [options.user]  - Player recipient ID
+ * @param {mongoose.ObjectId} [options.team]  - Team recipient ID
+ * @param {Object} options.actor              - Mongoose User or Team document
+ * @param {string} options.message            - Message text
+ * @param {string} [options.link]             - Optional link for more info
+ */
+async function createNotification({ user, team, actor, message, link = '' }) {
+  try {
+    // Determine which model the actor document belongs to so Mongoose can
+    // populate references correctly when retrieving notifications later.
+    const actorModel = actor?.constructor?.modelName;
+    if (!actorModel || (actorModel !== 'User' && actorModel !== 'Team')) {
+      throw new Error('Actor must be a User or Team document');
+    }
+
+    return await Notification.create({
+      user,
+      team,
+      actor: actor._id,
+      actorModel,
+      message,
+      link
+    });
+  } catch (err) {
+    console.error('Error creating notification:', err);
+    return null;
+  }
+}
+
+module.exports = { createNotification };


### PR DESCRIPTION
## Summary
- create Notification mongoose model to store user/team alerts
- add utility to create notification documents

## Testing
- `npm test --prefix server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861110d1b248328bb86ddf85d80f72f