### PR TITLE
Add user notification preferences

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -20,6 +20,35 @@ exports.updateMe = async (req, res) => {
       updates.firstName = firstName;
       updates.lastName = rest.join(' ');
     }
+    // Persist any notification preference changes
+    if (req.body.notificationPrefs) {
+      let prefs = req.body.notificationPrefs;
+      // When sent via multipart/form-data, the object may be a JSON string
+      if (typeof prefs === 'string') {
+        try {
+          prefs = JSON.parse(prefs);
+        } catch (e) {
+          console.error('Invalid notificationPrefs JSON');
+          prefs = null;
+        }
+      }
+      if (prefs) {
+        const keys = [
+          'scans',
+          'leaderboard',
+          'wallPosts',
+          'teamWallPosts',
+          'photoInteractions',
+          'sideQuestCompleted'
+        ];
+        // Use MongoDB dot notation to update individual fields
+        keys.forEach(key => {
+          if (typeof prefs[key] === 'boolean') {
+            updates[`notificationPrefs.${key}`] = prefs[key];
+          }
+        });
+      }
+    }
     if (req.files && req.files.selfie) {
       const avatarPath = '/uploads/' + req.files.selfie[0].filename;
       updates.photoUrl = avatarPath;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -10,7 +10,16 @@ const userSchema = new mongoose.Schema(
     photoUrl: { type: String, required: true },
     // Every player must be assigned to exactly one team
     team: { type: mongoose.Schema.Types.ObjectId, ref: 'Team', required: true },
-    isAdmin: { type: Boolean, default: false }          // true if this user created the team
+    isAdmin: { type: Boolean, default: false },         // true if this user created the team
+    // Each player can toggle which events generate notifications
+    notificationPrefs: {
+      scans: { type: Boolean, default: true },
+      leaderboard: { type: Boolean, default: true },
+      wallPosts: { type: Boolean, default: true },
+      teamWallPosts: { type: Boolean, default: true },
+      photoInteractions: { type: Boolean, default: true },
+      sideQuestCompleted: { type: Boolean, default: true }
+    }
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- extend `User` schema with `notificationPrefs`
- update `updateMe` to accept and save notification settings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68611599edc08328bf2a786b453c1157