### PR TITLE
Add notification controller and routes

### DIFF
--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -1,0 +1,61 @@
+const Notification = require('../models/Notification');
+
+/**
+ * Return notifications relevant to the authenticated player.
+ * By default this includes both personal and team notifications unless
+ * the request sets `req.teamOnly` to true.
+ */
+exports.getNotifications = async (req, res) => {
+  try {
+    const limit = parseInt(req.query.limit, 10) || 20;
+
+    // Build an array of query conditions depending on whether the user
+    // requested only team notifications or both personal and team ones.
+    const conditions = [];
+    if (req.teamOnly) {
+      // Only notifications addressed to the player's team
+      if (req.user.team) conditions.push({ team: req.user.team });
+    } else {
+      // Personal notifications always apply to the current player
+      conditions.push({ user: req.user._id });
+      // Include team notifications if the player belongs to a team
+      if (req.user.team) conditions.push({ team: req.user.team });
+    }
+
+    const notifications = await Notification.find({ $or: conditions })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      // Populate the actor so the client can display a name/photo
+      .populate('actor', 'name photoUrl');
+
+    res.json(notifications);
+  } catch (err) {
+    console.error('Error fetching notifications:', err);
+    res.status(500).json({ message: 'Error fetching notifications' });
+  }
+};
+
+/**
+ * Mark a notification as read if it belongs to the requesting user/team.
+ */
+exports.markRead = async (req, res) => {
+  try {
+    const note = await Notification.findById(req.params.id);
+    if (!note) return res.status(404).json({ message: 'Notification not found' });
+
+    // Ensure the player is allowed to update this notification
+    const ownsNote =
+      (note.user && note.user.equals(req.user._id)) ||
+      (note.team && req.user.team && note.team.equals(req.user.team));
+    if (!ownsNote) {
+      return res.status(403).json({ message: 'Not authorized to modify' });
+    }
+
+    note.read = true;
+    await note.save();
+    res.json({ message: 'Notification marked as read' });
+  } catch (err) {
+    console.error('Error updating notification:', err);
+    res.status(500).json({ message: 'Error updating notification' });
+  }
+};

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const { getNotifications, markRead } = require('../controllers/notificationController');
+
+// All notification routes require player authentication
+router.use(auth);
+
+// GET /api/notifications?limit=n - personal + team notifications
+router.get('/', getNotifications);
+
+// GET /api/notifications/team?limit=n - team notifications only
+router.get('/team', (req, res, next) => {
+  req.teamOnly = true; // flag for controller to filter team notifications
+  next();
+}, getNotifications);
+
+// PUT /api/notifications/:id/read - mark a notification as read
+router.put('/:id/read', markRead);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -70,6 +70,8 @@ app.use('/api/sidequests', require('./routes/sidequests'));
 app.use('/api/roguery', require('./routes/roguery'));
 // Players can react to rogues gallery items with emojis
 app.use('/api/reactions', require('./routes/reactions'));
+// Notifications for players and teams
+app.use('/api/notifications', require('./routes/notifications'));
 // Comment walls for player and team profiles
 app.use('/api/wall', require('./routes/wall'));
 app.use('/api', require('./routes/question'));


### PR DESCRIPTION
## Summary
- implement notification controller
- create notification routes
- mount notification routes in server

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68611e8a1d708328b5847e256d68b80f