### PR TITLE
Add notification support

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ThemeContext } from '../context/ThemeContext';
 import { fetchMe } from '../services/api';
+import NotificationBell from './NotificationBell';
 
 export default function Navbar() {
   const navigate = useNavigate();
@@ -99,6 +100,7 @@ export default function Navbar() {
             <Link to="/admin/login">Admin</Link>
           </li>
         )}
+        {token && <li><NotificationBell /></li>}
         {token && avatarUrl && (
           <li className="nav-avatar" style={{ position: 'relative' }}>
             <button

--- a/client/src/components/NotificationBell.js
+++ b/client/src/components/NotificationBell.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchNotifications, markNotificationRead } from '../services/api';
+
+/**
+ * Small bell icon used in the navbar.
+ * Requests Notification API permission on mount and displays a dropdown
+ * showing the five most recent notifications. A red dot indicates any
+ * unread items.
+ */
+export default function NotificationBell() {
+  const [notes, setNotes] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    // Ask the browser for permission to display notifications
+    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      Notification.requestPermission();
+    }
+    // Load the latest notifications
+    const load = async () => {
+      try {
+        const res = await fetchNotifications(5);
+        setNotes(res.data);
+      } catch (err) {
+        console.error('Failed to load notifications', err);
+      }
+    };
+    load();
+  }, []);
+
+  const unread = notes.some((n) => !n.read);
+
+  // Toggle dropdown visibility
+  const toggle = () => setOpen((v) => !v);
+
+  // Mark a single notification as read and update state
+  const handleMark = async (id) => {
+    try {
+      await markNotificationRead(id);
+      setNotes((prev) => prev.map((n) => (n._id === id ? { ...n, read: true } : n)));
+    } catch (err) {
+      console.error('Failed to mark notification as read', err);
+    }
+  };
+
+  return (
+    <div className="notification-bell" style={{ position: 'relative' }}>
+      <button onClick={toggle} aria-label="Notifications" style={{ background: 'none', border: 'none' }}>
+        🔔
+        {unread && <span className="notification-dot" />}
+      </button>
+      {open && (
+        <ul className="notification-dropdown">
+          {notes.length === 0 && <li>No notifications</li>}
+          {notes.map((n) => (
+            <li key={n._id} onClick={() => handleMark(n._id)}>
+              {n.link ? <Link to={n.link}>{n.message}</Link> : n.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/NotificationsList.js
+++ b/client/src/components/NotificationsList.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchNotifications, fetchTeamNotifications } from '../services/api';
+
+/**
+ * Simple list of notifications. If `teamOnly` is true only team notifications
+ * are fetched. Used on profile pages to show all recent items.
+ */
+export default function NotificationsList({ teamOnly = false }) {
+  const [notes, setNotes] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = teamOnly
+          ? await fetchTeamNotifications()
+          : await fetchNotifications();
+        setNotes(res.data);
+      } catch (err) {
+        console.error('Failed to load notifications', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [teamOnly]);
+
+  if (loading) return <p>Loading…</p>;
+  if (notes.length === 0) return <p>No notifications.</p>;
+
+  return (
+    <ul>
+      {notes.map((n) => (
+        <li key={n._id} style={{ marginBottom: '0.25rem' }}>
+          {n.link ? <Link to={n.link}>{n.message}</Link> : n.message}
+          {!n.read && ' (unread)'}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/client/src/pages/PlayerProfilePage.js
+++ b/client/src/pages/PlayerProfilePage.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchPlayerById } from '../services/api';
+import { fetchPlayerById, fetchMe } from '../services/api';
 import Wall from '../components/Wall';
+import NotificationsList from '../components/NotificationsList';
 
 // Read-only profile for any player
 export default function PlayerProfilePage() {
   const { id } = useParams(); // player id from the route
   const [player, setPlayer] = useState(null);
+  const [me, setMe] = useState(null); // logged in player
 
   useEffect(() => {
     // Load player data when id changes
@@ -14,6 +16,9 @@ export default function PlayerProfilePage() {
       try {
         const { data } = await fetchPlayerById(id);
         setPlayer(data);
+        // Also fetch current user to check if this is their profile
+        const meRes = await fetchMe();
+        setMe(meRes.data);
       } catch (err) {
         console.error(err);
       }
@@ -36,6 +41,13 @@ export default function PlayerProfilePage() {
       )}
       <p>Team: {player.team ? player.team.name : '-'}</p>
       <Wall type="user" id={id} />
+      {/* Show personal notifications when viewing your own profile */}
+      {me && me._id === id && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Notifications</h3>
+          <NotificationsList />
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/TeamProfilePage.js
+++ b/client/src/pages/TeamProfilePage.js
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchTeam } from '../services/api';
+import { fetchTeam, fetchMe } from '../services/api';
 import Wall from '../components/Wall';
+import NotificationsList from '../components/NotificationsList';
 
 // Displays a single team's details along with its comment wall
 export default function TeamProfilePage() {
   const { id } = useParams();
   const [team, setTeam] = useState(null);
+  const [me, setMe] = useState(null); // logged in player
 
   // Load team info on mount and when id changes
   useEffect(() => {
@@ -14,6 +16,9 @@ export default function TeamProfilePage() {
       try {
         const res = await fetchTeam(id);
         setTeam(res.data);
+        // Fetch logged in player for permission check
+        const meRes = await fetchMe();
+        setMe(meRes.data);
       } catch (err) {
         console.error(err);
       }
@@ -35,6 +40,13 @@ export default function TeamProfilePage() {
         />
       )}
       <Wall type="team" id={team._id} />
+      {/* Team-wide notifications shown only to members */}
+      {me && me.team && me.team._id === id && (
+        <div style={{ marginTop: '1rem' }}>
+          <h3>Team Notifications</h3>
+          <NotificationsList teamOnly />
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -171,3 +171,16 @@ export const updateSettingsAdmin = (data) =>
     headers: data instanceof FormData ? { 'Content-Type': 'multipart/form-data' } : undefined
   });
 
+// Notification endpoints
+// Retrieve recent notifications for the logged in player (and optionally team)
+export const fetchNotifications = (limit = 5) =>
+  axios.get(`/api/notifications?limit=${limit}`);
+
+// Retrieve only team notifications (excludes personal ones)
+export const fetchTeamNotifications = (limit = 5) =>
+  axios.get(`/api/notifications/team?limit=${limit}`);
+
+// Mark a notification as read
+export const markNotificationRead = (id) =>
+  axios.put(`/api/notifications/${id}/read`);
+

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -406,3 +406,40 @@ tbody tr:nth-child(even) {
   border-radius: 4px;
   cursor: pointer;
 }
+
+/* Notification bell in the navbar */
+.notification-bell button {
+  position: relative;
+  color: #fff;
+}
+
+.notification-dot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 8px;
+  height: 8px;
+  background: red;
+  border-radius: 50%;
+}
+
+.notification-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #333;
+  color: #fff;
+  padding: 0.5rem;
+  list-style: none;
+  min-width: 200px;
+  z-index: 1000;
+}
+
+.notification-dropdown li {
+  padding: 0.25rem 0;
+}
+
+.notification-dropdown a {
+  color: #fff;
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- extend API helpers for notification routes
- create NotificationBell with unread indicator
- display NotificationBell in the navbar
- add NotificationsList component
- show notifications on player and team profiles
- style notification widgets

## Testing
- `npm run build` in `client`
- `npm install` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68612506b86c83289f11d5005bc5120e