### PR TITLE
Add notification permission request

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ThemeContext } from './context/ThemeContext';
 import Navbar from './components/Navbar';
@@ -50,6 +50,18 @@ const AdminRoute = ({ children }) => {
 
 export default function App() {
   const { theme } = useContext(ThemeContext);
+
+  useEffect(() => {
+    // Request Notification permission once at startup if not already granted
+    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      const allow = window.confirm(
+        'Enable notifications to be alerted when new clues arrive?'
+      );
+      if (allow) {
+        Notification.requestPermission();
+      }
+    }
+  }, []);
 
   return (
     <div

--- a/client/src/components/NotificationBell.js
+++ b/client/src/components/NotificationBell.js
@@ -4,20 +4,15 @@ import { fetchNotifications, markNotificationRead } from '../services/api';
 
 /**
  * Small bell icon used in the navbar.
- * Requests Notification API permission on mount and displays a dropdown
- * showing the five most recent notifications. A red dot indicates any
- * unread items.
+ * Displays a dropdown showing the five most recent notifications.
+ * A red dot indicates any unread items.
  */
 export default function NotificationBell() {
   const [notes, setNotes] = useState([]);
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    // Ask the browser for permission to display notifications
-    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
-      Notification.requestPermission();
-    }
-    // Load the latest notifications
+    // Load the latest notifications when the component mounts
     const load = async () => {
       try {
         const res = await fetchNotifications(5);


### PR DESCRIPTION
## Summary
- show a confirmation prompt in `App` and request notification permission
- clean up `NotificationBell` which no longer handles permission request

## Testing
- `npm test` within `client` *(fails: Missing script)*
- `npm test` within `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686127ef171083289e86d918f42fb2c8