### PR TITLE
Add notification read tracking and menu auto-hide

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -34,6 +34,7 @@ import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
 import QrScanButton from './components/QrScanButton';
 import InstallPrompt from './components/InstallPrompt';
+import NotificationHandler from './components/NotificationHandler';
 
 // Guard for regular users
 const AuthRoute = ({ children }) => {
@@ -298,6 +299,8 @@ export default function App() {
         {/* Floating utilities shown on all pages */}
         <InstallPrompt />
         <QrScanButton />
+        {/* Mark notifications as read based on the URL */}
+        <NotificationHandler />
       </BrowserRouter>
     </div>
   );

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -62,6 +62,18 @@ export default function Navbar() {
     return () => document.removeEventListener('click', handleClick);
   }, []);
 
+  // Hide the avatar dropdown when clicking anywhere outside of it
+  useEffect(() => {
+    const handleAvatar = (e) => {
+      const menu = document.querySelector('.nav-avatar');
+      if (showMenu && menu && !menu.contains(e.target)) {
+        setShowMenu(false);
+      }
+    };
+    document.addEventListener('click', handleAvatar);
+    return () => document.removeEventListener('click', handleAvatar);
+  }, [showMenu]);
+
   const handleLogout = () => {
     localStorage.removeItem('token');
     localStorage.removeItem('adminToken');

--- a/client/src/components/NotificationHandler.js
+++ b/client/src/components/NotificationHandler.js
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { markNotificationRead } from '../services/api';
+
+/**
+ * Global component that watches the current URL for a `note` query
+ * parameter. When present, it marks that notification as read via
+ * the API. This component renders nothing and simply performs the
+ * side effect whenever the route changes.
+ */
+export default function NotificationHandler() {
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const id = params.get('note');
+    if (id) {
+      // Fire and forget – the notification bell will refresh later
+      markNotificationRead(id).catch((err) =>
+        console.error('Failed to mark notification as read', err)
+      );
+    }
+  }, [location]);
+
+  return null;
+}

--- a/client/src/components/NotificationsList.js
+++ b/client/src/components/NotificationsList.js
@@ -10,6 +10,19 @@ export default function NotificationsList({ teamOnly = false }) {
   const [notes, setNotes] = useState([]);
   const [loading, setLoading] = useState(true);
 
+  // Append the notification id to any provided link so the destination page
+  // can mark it as read when visited
+  const buildLink = (note) => {
+    if (!note.link) return '';
+    try {
+      const url = new URL(note.link, window.location.origin);
+      url.searchParams.set('note', note._id);
+      return url.pathname + url.search + url.hash;
+    } catch {
+      return note.link;
+    }
+  };
+
   useEffect(() => {
     const load = async () => {
       try {
@@ -33,7 +46,7 @@ export default function NotificationsList({ teamOnly = false }) {
     <ul>
       {notes.map((n) => (
         <li key={n._id} style={{ marginBottom: '0.25rem' }}>
-          {n.link ? <Link to={n.link}>{n.message}</Link> : n.message}
+          {n.link ? <Link to={buildLink(n)}>{n.message}</Link> : n.message}
           {!n.read && ' (unread)'}
         </li>
       ))}


### PR DESCRIPTION
## Summary
- mark notifications as read when landing on linked pages
- hide notification and avatar menus when clicking away
- attach notification IDs to links
- add utility component to watch page URL for notification IDs

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68619d06da7c8328a03abe11b29d9d90