### PR TITLE
Implement shared colour palette

### DIFF
--- a/client/src/context/ThemeContext.js
+++ b/client/src/context/ThemeContext.js
@@ -39,15 +39,7 @@ export const ThemeProvider = ({ children }) => {
       if (globalRes.data.logoUrl) th.logoUrl = globalRes.data.logoUrl;
       if (globalRes.data.faviconUrl) th.faviconUrl = globalRes.data.faviconUrl;
 
-      const token = localStorage.getItem('token');
-      // Only apply team-specific colours when not explicitly ignored
-      if (token && !opts.ignoreTeam) {
-        const userRes = await axios.get('/api/users/me');
-        const teamId = userRes.data.team._id;
-        const teamRes = await axios.get(`/api/teams/${teamId}`);
-        const cs = teamRes.data.colourScheme;
-        th = { ...th, primary: cs.primary, secondary: cs.secondary };
-      }
+      // Team colours are no longer applied so everyone shares the admin palette
       setTheme(th);
     } catch (err) {
       console.error('Error fetching theme:', err);

--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -4,9 +4,26 @@ import ImageSelector from '../components/ImageSelector';
 import { ThemeContext } from '../context/ThemeContext';
 import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
 
+// Pre-defined colour palettes used by the admin to theme the game
+// Each palette consists of a primary and secondary colour
+export const COLOUR_PALETTES = [
+  { name: 'Ocean', primary: '#007AFF', secondary: '#5856D6' },
+  { name: 'Sunset', primary: '#FF4500', secondary: '#FFA500' },
+  { name: 'Forest', primary: '#228B22', secondary: '#2E8B57' },
+  { name: 'Rose', primary: '#C71585', secondary: '#FF69B4' },
+  { name: 'Aqua', primary: '#20B2AA', secondary: '#40E0D0' },
+  { name: 'Slate', primary: '#708090', secondary: '#2F4F4F' },
+  { name: 'Berry', primary: '#8A2BE2', secondary: '#BA55D3' },
+  { name: 'Citrus', primary: '#FF8C00', secondary: '#FFD700' },
+  { name: 'Lime', primary: '#9ACD32', secondary: '#6B8E23' },
+  { name: 'Steel', primary: '#4682B4', secondary: '#5F9EA0' }
+];
+
 // Page allowing admin users to configure global game settings
 export default function AdminSettingsPage() {
   const { refreshTheme, updateTheme } = useContext(ThemeContext);
+  // Track which palette is selected in the UI
+  const [paletteIndex, setPaletteIndex] = useState(0);
   const [settings, setSettings] = useState({
     gameName: '',
     qrBaseUrl: '',
@@ -32,6 +49,13 @@ export default function AdminSettingsPage() {
       try {
         const { data } = await fetchSettingsAdmin();
         setSettings(data);
+        // Determine which palette matches the saved theme
+        const idx = COLOUR_PALETTES.findIndex(
+          (p) =>
+            p.primary === data.theme.primary &&
+            p.secondary === data.theme.secondary
+        );
+        if (idx >= 0) setPaletteIndex(idx);
       } catch (err) {
         console.error(err);
       }
@@ -125,28 +149,29 @@ export default function AdminSettingsPage() {
       />
 
       <h3>Appearance</h3>
-      <label>Primary Colour:</label>
-      <input
-        type="color"
-        value={settings.theme.primary}
-        onChange={(e) =>
+      <label>Colour Palette:</label>
+      {/* Choose from ten predefined palettes so colours are consistent */}
+      <select
+        value={paletteIndex}
+        onChange={(e) => {
+          const idx = parseInt(e.target.value, 10);
+          setPaletteIndex(idx);
+          const pal = COLOUR_PALETTES[idx];
+          // Immediately update local settings so the preview refreshes
           setSettings({
             ...settings,
-            theme: { ...settings.theme, primary: e.target.value }
-          })
-        }
-      />
-      <label>Secondary Colour:</label>
-      <input
-        type="color"
-        value={settings.theme.secondary}
-        onChange={(e) =>
-          setSettings({
-            ...settings,
-            theme: { ...settings.theme, secondary: e.target.value }
-          })
-        }
-      />
+            theme: { primary: pal.primary, secondary: pal.secondary }
+          });
+          // Update the applied theme colours right away
+          updateTheme(pal.primary, pal.secondary);
+        }}
+      >
+        {COLOUR_PALETTES.map((p, i) => (
+          <option key={p.name} value={i}>
+            {p.name}
+          </option>
+        ))}
+      </select>
       <label>Font:</label>
       <select
         value={settings.fontFamily}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -2,8 +2,10 @@
   /* CSS variables allow dynamic theming via admin settings */
   --primary-color: #007AFF;
   --secondary-color: #5856D6;
-  --background-color: #ffffff;
-  --text-color: #333;
+  /* Slightly off-white background so white elements stand out */
+  --background-color: #f9f9f9;
+  /* Darker text for better contrast */
+  --text-color: #222;
   /* Shadows used for a soft neumorphic look */
   --shadow-light: rgba(255, 255, 255, 0.7);
   --shadow-dark: rgba(0, 0, 0, 0.1);
@@ -320,7 +322,8 @@ form label {
 .hamburger {
   background: none;
   border: none;
-  color: #fff;
+  /* Use text colour so the icon contrasts with the navbar */
+  color: var(--text-color);
   font-size: 1.75rem;
   cursor: pointer;
   margin-right: 0.75rem;
@@ -457,7 +460,8 @@ tbody tr:nth-child(even) {
 /* Notification bell in the navbar */
 .notification-bell button {
   position: relative;
-  color: #fff;
+  /* Match regular text colour so it's visible on light backgrounds */
+  color: var(--text-color);
 }
 
 .notification-dot {


### PR DESCRIPTION
## Summary
- ensure fonts contrast properly on new style
- create 10 predefined colour palettes for admins
- update Admin Settings page to pick from palettes
- drop team-specific colours so everyone shares the same palette

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4f94d4c83289065142ac6d1927a