### PR TITLE
Fix notifications feature

### DIFF
--- a/client/src/components/NotificationBell.js
+++ b/client/src/components/NotificationBell.js
@@ -49,7 +49,8 @@ export default function NotificationBell() {
   const handleMark = async (id) => {
     try {
       await markNotificationRead(id);
-      setNotes((prev) => prev.map((n) => (n._id === id ? { ...n, read: true } : n)));
+      // Remove the notification from the dropdown once read
+      setNotes((prev) => prev.filter((n) => n._id !== id));
     } catch (err) {
       console.error('Failed to mark notification as read', err);
     }
@@ -88,8 +89,7 @@ export default function NotificationBell() {
             <li
               key={n._id}
               onClick={() => {
-                // Non-linked items are marked read immediately
-                if (!n.link) handleMark(n._id);
+                handleMark(n._id);
                 // Hide the dropdown after any selection
                 setOpen(false);
               }}

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -12,13 +12,14 @@ const notificationSchema = new mongoose.Schema(
     // whether this ObjectId references a User or Team document.
     actor: {
       type: mongoose.Schema.Types.ObjectId,
-      required: true,
+      // For system notifications this will be undefined
       refPath: 'actorModel'
     },
     actorModel: {
       type: String,
-      required: true,
-      enum: ['User', 'Team']
+      enum: ['User', 'Team', 'System'],
+      // Default to "System" when no actor document is supplied
+      default: 'System'
     },
     message: { type: String, required: true }, // text shown to the recipient
     link: { type: String, default: '' },       // optional URL for more details

--- a/server/tests/notifications.test.js
+++ b/server/tests/notifications.test.js
@@ -3,6 +3,9 @@ const mongoose = require('mongoose');
 const jwt = require('jsonwebtoken');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 
+// Integration tests spin up an in-memory MongoDB which can take a few seconds
+jest.setTimeout(30000);
+
 const Notification = require('../models/Notification');
 const User = require('../models/User');
 const Team = require('../models/Team');
@@ -89,6 +92,16 @@ describe('createNotification', () => {
     // Newly created note should reference the correct actor model
     expect(note.actorModel).toBe('User');
     expect(note.user.toString()).toBe(user1._id.toString());
+  });
+
+  test('creates a system notification when no actor provided', async () => {
+    const note = await createNotification({
+      user: user1._id,
+      message: 'System message'
+    });
+    expect(note).toBeTruthy();
+    expect(note.actor).toBeUndefined();
+    expect(note.actorModel).toBe('System');
   });
 
   test('returns null when actor is invalid', async () => {

--- a/server/utils/notifications.js
+++ b/server/utils/notifications.js
@@ -13,17 +13,23 @@ const Notification = require('../models/Notification');
  */
 async function createNotification({ user, team, actor, message, link = '' }) {
   try {
-    // Determine which model the actor document belongs to so Mongoose can
+    let actorId;
+    let actorModel = 'System';
+
+    // If an actor document is supplied determine its model so Mongoose can
     // populate references correctly when retrieving notifications later.
-    const actorModel = actor?.constructor?.modelName;
-    if (!actorModel || (actorModel !== 'User' && actorModel !== 'Team')) {
-      throw new Error('Actor must be a User or Team document');
+    if (actor) {
+      actorModel = actor.constructor?.modelName;
+      if (!['User', 'Team'].includes(actorModel)) {
+        throw new Error('Actor must be a User or Team document');
+      }
+      actorId = actor._id;
     }
 
     return await Notification.create({
       user,
       team,
-      actor: actor._id,
+      actor: actorId,
       actorModel,
       message,
       link


### PR DESCRIPTION
## Summary
- support `System` notifications without an actor
- automatically remove read notifications from the bell
- keep actor optional in Notification model
- test system notifications and allow more time for tests

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6862993a02f483289feafe6e3e4a3f2d