### PR TITLE
Improve gallery layout and reactions

### DIFF
--- a/client/src/pages/RoguesGalleryPage.js
+++ b/client/src/pages/RoguesGalleryPage.js
@@ -104,15 +104,9 @@ export default function RoguesGalleryPage() {
           Show All
         </button>
       </div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-          gap: '1rem'
-        }}
-      >
+      <div className="rogue-grid">
         {filteredMedia.map((m) => (
-          <RogueItem key={m._id} media={m} />
+          <RogueItem key={m._id} media={m} showInfo={false} />
         ))}
       </div>
     </div>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -232,8 +232,8 @@ form label {
 
 .rogue-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 0.75rem;
 }
 
 /* Utility class to add margin around card elements */
@@ -494,4 +494,68 @@ tbody tr:nth-child(even) {
 .notification-dropdown a {
   color: var(--text-color);
   text-decoration: underline;
+}
+
+/* ──────────────── ROGUES GALLERY ──────────────── */
+.gallery-tile {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  overflow: hidden;
+}
+
+.gallery-image,
+.gallery-tile video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.reaction-bar {
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 2px 6px;
+  border-radius: 20px;
+}
+
+.reaction-bar span {
+  color: #fff;
+  margin-right: 4px;
+  font-size: 0.85rem;
+}
+
+.react-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.reaction-picker {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 4px 8px;
+  border-radius: 20px;
+}
+
+.reaction-picker button {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.25rem;
+  margin: 0 3px;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- make gallery grid use square tiles and lighten layout
- add reaction picker overlay to gallery items
- use new grid on `RoguesGalleryPage`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862afb84f30832881be4498c13c6514