### PR TITLE
Implement passcode and trivia side quests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project contains a React client and an Express/MongoDB server for running a
 - Simplified signup using only first and last name
 - Sequential clues with answer submission
 - Side quests and a rogues gallery for uploaded media
+- New "passcode" and "trivia" side quest types with in-app validation
 - Admin authentication and dashboard endpoints
 - Team colour schemes and profile management
 - Installable Progressive Web App with offline support
@@ -14,6 +15,7 @@ This project contains a React client and an Express/MongoDB server for running a
   `definitely` as confirmation
 - Send a real-time **alert to all players** from the admin settings page to test notifications
 - Scanning QR codes requires login; unauthenticated scans redirect to the sign-in page
+- Some quests ask for a passcode or trivia answer before your proof is accepted
 
 ## Player Onboarding and Login
 Players still enter only their first and last name, but a selfie must be

--- a/client/src/pages/SideQuestDetailPage.js
+++ b/client/src/pages/SideQuestDetailPage.js
@@ -8,6 +8,8 @@ export default function SideQuestDetailPage() {
   const { id } = useParams();
   const [quest, setQuest] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [passcode, setPasscode] = useState(''); // passcode input for secret quests
+  const [answer, setAnswer] = useState(''); // selected answer for trivia quests
 
   useEffect(() => {
     const load = async () => {
@@ -25,6 +27,13 @@ export default function SideQuestDetailPage() {
 
   const handleUpload = async (formData) => {
     try {
+      // Include passcode or trivia answer when applicable
+      if (quest.questType === 'passcode') {
+        formData.append('passcode', passcode);
+      }
+      if (quest.questType === 'trivia') {
+        formData.append('answer', answer);
+      }
       await submitSideQuest(id, formData);
       alert('Submission received!');
     } catch (err) {
@@ -47,6 +56,32 @@ export default function SideQuestDetailPage() {
             alt={quest.title}
             style={{ width: '100%', borderRadius: '4px', marginTop: '1rem' }}
           />
+        )}
+        {/* Extra fields for special quest types */}
+        {quest.questType === 'passcode' && (
+          <input
+            type="text"
+            placeholder="Enter passcode"
+            value={passcode}
+            onChange={(e) => setPasscode(e.target.value)}
+            style={{ marginTop: '0.5rem' }}
+          />
+        )}
+        {quest.questType === 'trivia' && (
+          <div style={{ marginTop: '0.5rem' }}>
+            {quest.options.map((o) => (
+              <label key={o} style={{ display: 'block' }}>
+                <input
+                  type="radio"
+                  name="answer"
+                  value={o}
+                  checked={answer === o}
+                  onChange={(e) => setAnswer(e.target.value)}
+                />
+                {o}
+              </label>
+            ))}
+          </div>
         )}
         <div style={{ marginTop: '1rem' }}>
           <PhotoUploader

--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -169,6 +169,25 @@ exports.submitSideQuestProof = async (req, res) => {
       return res.status(400).json({ message: 'Quest already completed' });
     }
 
+    // If the quest requires a passcode or trivia answer validate it now
+    if (sq.questType === 'passcode') {
+      const pass = (req.body.passcode || '').trim().toLowerCase();
+      if (!pass || pass !== sq.passcode?.trim().toLowerCase()) {
+        return res.status(400).json({ message: 'Incorrect passcode' });
+      }
+    }
+
+    if (sq.questType === 'trivia') {
+      const ans = (req.body.answer || '').trim().toLowerCase();
+      if (!ans) {
+        return res.status(400).json({ message: 'Answer required' });
+      }
+      const correct = sq.correctOption?.trim().toLowerCase();
+      if (ans !== correct) {
+        return res.status(400).json({ message: 'Incorrect answer' });
+      }
+    }
+
     let mediaUrl = '';
     // Store uploaded photo/video if present
     if (


### PR DESCRIPTION
## Summary
- validate passcodes and trivia answers on the server
- support passcode and trivia inputs on side quest pages
- document new side quest types in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862f12032708328adcfb0c62b9ed83d