### PR TITLE
Add photo previews with cancel option

### DIFF
--- a/client/src/components/PhotoUploader.js
+++ b/client/src/components/PhotoUploader.js
@@ -4,7 +4,7 @@ import ImageSelector from './ImageSelector';
 // Widget allowing players to attach media to side quest submissions.
 // For photo quests we let the user either capture a new image or upload one.
 function PhotoUploader({ label, requiredMediaType, onUpload }) {
-  const [file, setFile] = useState(null);   // selected File object
+  const [file, setFile] = useState(null);   // currently selected File object
   const [preview, setPreview] = useState(''); // preview URL or filename
 
   // Reads the chosen file and sets up a preview
@@ -19,8 +19,15 @@ function PhotoUploader({ label, requiredMediaType, onUpload }) {
       };
       reader.readAsDataURL(f);
     } else {
+      // For videos we simply show the filename
       setPreview(f.name);
     }
+  };
+
+  // Remove the chosen file and reset preview
+  const handleClear = () => {
+    setFile(null);
+    setPreview('');
   };
 
   // Send the selected file to the parent component as FormData
@@ -47,18 +54,36 @@ function PhotoUploader({ label, requiredMediaType, onUpload }) {
             onChange={(e) => handleFileSelect(e.target.files[0])}
           />
         )}
-        {preview && requiredMediaType === 'photo' && (
-          <img
-            src={preview}
-            alt="Preview"
-            style={{ width: '120px', borderRadius: '4px', marginTop: '0.5rem' }}
-          />
-        )}
-        {preview && requiredMediaType === 'video' && <p>Selected video: {preview}</p>}
-        <button type="submit">Submit</button>
-      </form>
-    </div>
-  );
-}
+          {preview && requiredMediaType === 'photo' && (
+            <div style={{ position: 'relative', display: 'inline-block' }}>
+              <img
+                src={preview}
+                alt="Preview"
+                style={{ width: '120px', borderRadius: '4px', marginTop: '0.5rem' }}
+              />
+              {/* Allow clearing the selected image */}
+              <button
+                type="button"
+                onClick={handleClear}
+                style={{ position: 'absolute', top: 0, right: 0 }}
+                aria-label="Remove"
+              >
+                ✕
+              </button>
+            </div>
+          )}
+          {preview && requiredMediaType === 'video' && (
+            <p>
+              Selected video: {preview}
+              <button type="button" onClick={handleClear} className="btn-ml">
+                Cancel
+              </button>
+            </p>
+          )}
+          <button type="submit">Submit</button>
+        </form>
+      </div>
+    );
+  }
 
 export default PhotoUploader;

--- a/client/src/components/ProfilePic.js
+++ b/client/src/components/ProfilePic.js
@@ -14,14 +14,31 @@ export default function ProfilePic({ avatarUrl, onFileSelect }) {
     reader.readAsDataURL(file);
   };
 
+  // Clear the chosen avatar
+  const handleClear = () => {
+    setPreview('');
+    onFileSelect(null);
+  };
+
   return (
     <div>
       {preview && (
-        <img
-          src={preview}
-          alt="Avatar Preview"
-          style={{ width: '100px', height: '100px', borderRadius: '50%', objectFit: 'cover' }}
-        />
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <img
+            src={preview}
+            alt="Avatar Preview"
+            style={{ width: '100px', height: '100px', borderRadius: '50%', objectFit: 'cover' }}
+          />
+          {/* Provide a cancel button so the user can start over */}
+          <button
+            type="button"
+            onClick={handleClear}
+            style={{ position: 'absolute', top: 0, right: 0 }}
+            aria-label="Remove"
+          >
+            ✕
+          </button>
+        </div>
       )}
       {/* Use ImageSelector so the user can take or upload a photo */}
       <ImageSelector onSelect={handleFileSelect} />


### PR DESCRIPTION
## Summary
- show thumbnail preview and cancel button when selecting profile photos
- display preview with ability to clear selection in side quest photo uploader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862f8486864832896dd3e6f29a10a31