### PR TITLE
Fix side quest load and create button

### DIFF
--- a/client/src/pages/CreateSideQuestPage.js
+++ b/client/src/pages/CreateSideQuestPage.js
@@ -36,31 +36,41 @@ export default function CreateSideQuestPage() {
   return (
     <div className="card spaced-card">
       <h2>Create Side Quest</h2>
-      <div style={{ marginBottom: '1rem' }}>
-        <label style={{ display: 'block', marginBottom: '0.5rem' }}>
-          Name:
-          <input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            style={{ marginLeft: '0.5rem' }}
-          />
-        </label>
-        <label style={{ display: 'block' }}>
-          Type:
-          <select
-            value={questType}
-            onChange={(e) => setQuestType(e.target.value)}
-            style={{ marginLeft: '0.5rem' }}
-          >
-            {questTypeOptions.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
-      <button onClick={handleCreate} disabled={!title}>Continue</button>
+      {/* Wrapping the fields in a form allows the Enter key to submit */}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleCreate();
+        }}
+      >
+        <div style={{ marginBottom: '1rem' }}>
+          <label style={{ display: 'block', marginBottom: '0.5rem' }}>
+            Name:
+            <input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              style={{ marginLeft: '0.5rem' }}
+            />
+          </label>
+          <label style={{ display: 'block' }}>
+            Type:
+            <select
+              value={questType}
+              onChange={(e) => setQuestType(e.target.value)}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              {questTypeOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <button type="submit" disabled={!title}>
+          Continue
+        </button>
+      </form>
     </div>
   );
 }

--- a/client/src/pages/SideQuestEditPage.js
+++ b/client/src/pages/SideQuestEditPage.js
@@ -15,15 +15,6 @@ export default function SideQuestEditPage() {
   const [loading, setLoading] = useState(true);
   const [scannedItems, setScannedItems] = useState([]); // used for bonus quests
 
-  // Load quest details and scanned items when the id changes
-  useEffect(() => {
-    if (id) {
-      loadQuest();
-      loadScanned();
-    }
-  }, [id, loadQuest, loadScanned]);
-
-  // Retrieve the quest from the API
   // Retrieve the quest from the API. Memoized so React Hook rules
   // can list it as a dependency without re-running unnecessarily.
   const loadQuest = useCallback(async () => {
@@ -53,6 +44,14 @@ export default function SideQuestEditPage() {
       console.error(err);
     }
   }, []);
+
+  // Load quest details and scanned items when the id changes
+  useEffect(() => {
+    if (id) {
+      loadQuest();
+      loadScanned();
+    }
+  }, [id, loadQuest, loadScanned]);
 
   // Save updated fields
   const handleSave = async () => {


### PR DESCRIPTION
## Summary
- fix load order for hooks in `SideQuestEditPage`
- submit the create side quest form with an actual button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863ad80860083288a44867e5f4638fb