### PR TITLE
Add viewable notifications

### DIFF
--- a/client/src/components/NotificationsList.js
+++ b/client/src/components/NotificationsList.js
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchNotifications, fetchTeamNotifications } from '../services/api';
+import {
+  fetchNotifications,
+  fetchTeamNotifications,
+  markNotificationViewed
+} from '../services/api';
 
 /**
  * Simple list of notifications. If `teamOnly` is true only team notifications
@@ -30,6 +34,14 @@ export default function NotificationsList({ teamOnly = false }) {
           ? await fetchTeamNotifications()
           : await fetchNotifications();
         setNotes(res.data);
+        // Mark any newly retrieved notifications as viewed
+        res.data.forEach((n) => {
+          if (!n.viewed) {
+            markNotificationViewed(n._id).catch((err) =>
+              console.error('Failed to mark notification as viewed', err)
+            );
+          }
+        });
       } catch (err) {
         console.error('Failed to load notifications', err);
       } finally {
@@ -46,8 +58,14 @@ export default function NotificationsList({ teamOnly = false }) {
     <ul>
       {notes.map((n) => (
         <li key={n._id} style={{ marginBottom: '0.25rem' }}>
-          {n.link ? <Link to={buildLink(n)}>{n.message}</Link> : n.message}
-          {!n.read && ' (unread)'}
+          {n.link ? (
+            <Link to={buildLink(n)} style={{ fontWeight: n.read ? 'normal' : 'bold' }}>
+              {n.message}
+            </Link>
+          ) : (
+            <span style={{ fontWeight: n.read ? 'normal' : 'bold' }}>{n.message}</span>
+          )}
+          {!n.viewed ? ' (new)' : !n.read ? ' (unread)' : ''}
         </li>
       ))}
     </ul>

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -194,6 +194,10 @@ export const fetchTeamNotifications = (limit = 5) =>
 export const markNotificationRead = (id) =>
   axios.put(`/api/notifications/${id}/read`);
 
+// Mark a notification as viewed
+export const markNotificationViewed = (id) =>
+  axios.put(`/api/notifications/${id}/viewed`);
+
 // Admin endpoint to broadcast a system notification to all players
 export const broadcastNotification = (message) =>
   axios.post('/api/admin/notifications/broadcast', { message });

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -59,3 +59,27 @@ exports.markRead = async (req, res) => {
     res.status(500).json({ message: 'Error updating notification' });
   }
 };
+
+/**
+ * Mark a notification as viewed the first time it is shown to the player.
+ */
+exports.markViewed = async (req, res) => {
+  try {
+    const note = await Notification.findById(req.params.id);
+    if (!note) return res.status(404).json({ message: 'Notification not found' });
+
+    const ownsNote =
+      (note.user && note.user.equals(req.user._id)) ||
+      (note.team && req.user.team && note.team.equals(req.user.team));
+    if (!ownsNote) {
+      return res.status(403).json({ message: 'Not authorized to modify' });
+    }
+
+    note.viewed = true;
+    await note.save();
+    res.json({ message: 'Notification marked as viewed' });
+  } catch (err) {
+    console.error('Error updating notification:', err);
+    res.status(500).json({ message: 'Error updating notification' });
+  }
+};

--- a/server/middleware/upload.js
+++ b/server/middleware/upload.js
@@ -12,8 +12,9 @@ const uploadDir = path.join(__dirname, '..', 'uploads');
 // Without this check, multer would throw an ENOENT error the first time an
 // admin tries to upload a logo or favicon because the directory hasn't been
 // created yet on fresh installs.
+// Create the directory recursively to avoid EEXIST errors in tests
 if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir);
+  fs.mkdirSync(uploadDir, { recursive: true });
 }
 
 // Store uploads in the “uploads/” folder with a random UUID filename

--- a/server/models/Notification.js
+++ b/server/models/Notification.js
@@ -23,6 +23,8 @@ const notificationSchema = new mongoose.Schema(
     },
     message: { type: String, required: true }, // text shown to the recipient
     link: { type: String, default: '' },       // optional URL for more details
+    // Has the notification been shown to the player yet?
+    viewed: { type: Boolean, default: false },
     read: { type: Boolean, default: false }    // whether the recipient has read it
   },
   { timestamps: true }

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const auth = require('../middleware/auth');
-const { getNotifications, markRead } = require('../controllers/notificationController');
+const { getNotifications, markRead, markViewed } = require('../controllers/notificationController');
 
 // All notification routes require player authentication
 router.use(auth);
@@ -17,5 +17,8 @@ router.get('/team', (req, res, next) => {
 
 // PUT /api/notifications/:id/read - mark a notification as read
 router.put('/:id/read', markRead);
+
+// PUT /api/notifications/:id/viewed - mark a notification as viewed
+router.put('/:id/viewed', markViewed);
 
 module.exports = router;

--- a/server/tests/notifications.test.js
+++ b/server/tests/notifications.test.js
@@ -151,6 +151,16 @@ describe('/api/notifications endpoints', () => {
     expect(updated.read).toBe(true);
   });
 
+  test('PUT /api/notifications/:id/viewed marks as viewed', async () => {
+    const res = await request(app)
+      .put(`/api/notifications/${teamNote._id}/viewed`)
+      .set('Authorization', `Bearer ${token2}`);
+
+    expect(res.statusCode).toBe(200);
+    const updated = await Notification.findById(teamNote._id);
+    expect(updated.viewed).toBe(true);
+  });
+
   test('PUT /api/notifications/:id/read blocks other users', async () => {
     const res = await request(app)
       .put(`/api/notifications/${personalNote._id}/read`)


### PR DESCRIPTION
## Summary
- track whether notifications have been displayed
- support marking notifications as viewed
- show new/unread statuses in notification bell and profile list
- expose `/api/notifications/:id/viewed` endpoint
- ensure upload middleware creates directory recursively

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863bb3948548328a7875b4d5e0d1bcd