### PR TITLE
Add sidequest instructions admin page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,6 +32,7 @@ import AdminPlayersPage from './pages/AdminPlayersPage';
 import AdminTeamsPage from './pages/AdminTeamsPage';
 import AdminGalleryPage from './pages/AdminGalleryPage';
 import AdminSettingsPage from './pages/AdminSettingsPage';
+import AdminInstructionsPage from './pages/AdminInstructionsPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
@@ -309,6 +310,14 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminSettingsPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/instructions"
+                element={
+                  <AdminRoute>
+                    <AdminInstructionsPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -56,6 +56,7 @@ export default function Sidebar() {
           {renderLink('/admin/teams', 'Teams')}
           {renderLink('/admin/gallery', 'Gallery')}
           {renderLink('/admin/settings', 'Settings')}
+          {renderLink('/admin/instructions', 'Instructions')}
         </>
       )}
     </aside>

--- a/client/src/pages/AdminInstructionsPage.js
+++ b/client/src/pages/AdminInstructionsPage.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
+
+// Admin page for editing the default instructions shown for each
+// side quest type. The values are stored on the Settings document
+// under `sideQuestInstructions`.
+export default function AdminInstructionsPage() {
+  const [instr, setInstr] = useState({
+    bonus: '',
+    meetup: '',
+    photo: '',
+    race: '',
+    passcode: '',
+    trivia: ''
+  });
+
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data } = await fetchSettingsAdmin();
+        setInstr(data.sideQuestInstructions || instr);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Save the updated instructions back to the server
+  const handleSave = async () => {
+    try {
+      const payload = new FormData();
+      payload.append('sideQuestInstructions', JSON.stringify(instr));
+      await updateSettingsAdmin(payload);
+      alert('Instructions saved');
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error saving instructions');
+    }
+  };
+
+  if (loading) return <p>Loading…</p>;
+
+  // Helper to render a labelled textarea for a quest type
+  const Field = ({ type, label }) => (
+    <label style={{ display: 'block', marginBottom: '1rem' }}>
+      {label}:
+      <textarea
+        value={instr[type] || ''}
+        onChange={(e) => setInstr({ ...instr, [type]: e.target.value })}
+        style={{ width: '100%', height: '4rem', marginTop: '0.25rem' }}
+      />
+    </label>
+  );
+
+  return (
+    <div className="card spaced-card" style={{ maxWidth: '600px' }}>
+      <h2>Side Quest Instructions</h2>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSave();
+        }}
+      >
+        <Field type="bonus" label="Bonus" />
+        <Field type="meetup" label="Meetup" />
+        <Field type="photo" label="Photo" />
+        <Field type="race" label="Race" />
+        <Field type="passcode" label="Passcode" />
+        <Field type="trivia" label="Trivia" />
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/pages/SideQuestPage.js
+++ b/client/src/pages/SideQuestPage.js
@@ -1,18 +1,27 @@
 import React, { useEffect, useState } from 'react';
-import { fetchSideQuests, submitSideQuest } from '../services/api';
+import {
+  fetchSideQuests,
+  submitSideQuest,
+  fetchSettings
+} from '../services/api';
 import PhotoUploader from '../components/PhotoUploader';
 
 export default function SideQuestPage() {
   // List of available quests
   const [quests, setQuests] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [defaults, setDefaults] = useState({});
 
   useEffect(() => {
     // Load quest data on mount
     const load = async () => {
       try {
-        const { data } = await fetchSideQuests();
-        setQuests(data);
+        const [qRes, sRes] = await Promise.all([
+          fetchSideQuests(),
+          fetchSettings()
+        ]);
+        setQuests(qRes.data);
+        setDefaults(sRes.data.sideQuestInstructions || {});
       } catch (err) {
         console.error(err);
       } finally {
@@ -42,12 +51,30 @@ export default function SideQuestPage() {
   const QuestItem = ({ quest }) => {
     const [code, setCode] = useState('');
     const [ans, setAns] = useState('');
+    const instructionsText = quest.instructions || defaults[quest.questType];
+    const [timeLeft, setTimeLeft] = useState(
+      quest.timeLimitSeconds ? quest.timeLimitSeconds : null
+    );
+
+    // Countdown timer when applicable
+    useEffect(() => {
+      if (timeLeft === null) return;
+      if (timeLeft <= 0) return;
+      const timer = setInterval(() => {
+        setTimeLeft((t) => (t > 0 ? t - 1 : 0));
+      }, 1000);
+      return () => clearInterval(timer);
+    }, [timeLeft]);
 
     return (
       <div key={quest._id} style={{ marginBottom: '1rem' }}>
         <div className="card" style={{ marginBottom: '0.5rem' }}>
           <h3>{quest.title}</h3>
           <p>{quest.text}</p>
+          {instructionsText && <p>{instructionsText}</p>}
+          {timeLeft !== null && (
+            <p style={{ fontWeight: 'bold' }}>Time remaining: {timeLeft}s</p>
+          )}
           {quest.imageUrl && (
             <img
               src={quest.imageUrl}

--- a/server/controllers/settingsController.js
+++ b/server/controllers/settingsController.js
@@ -37,6 +37,16 @@ exports.updateSettings = async (req, res) => {
       }
     }
 
+    // sideQuestInstructions may be sent as a JSON string; parse it when needed
+    if (typeof updates.sideQuestInstructions === 'string') {
+      try {
+        updates.sideQuestInstructions = JSON.parse(updates.sideQuestInstructions);
+      } catch (e) {
+        console.error('Invalid sideQuestInstructions JSON');
+        delete updates.sideQuestInstructions;
+      }
+    }
+
     // Attach uploaded files if present
     if (req.files && req.files.logo && req.files.logo[0]) {
       updates.logoUrl = '/uploads/' + req.files.logo[0].filename;

--- a/server/models/Settings.js
+++ b/server/models/Settings.js
@@ -25,7 +25,37 @@ const settingsSchema = new mongoose.Schema({
   scorePerSideQuest: { type: Number, default: 5 },
   scorePerCreatedQuest: { type: Number, default: 20 },
   // Number of minutes teams must wait before changing a trivia answer
-  questionAnswerCooldown: { type: Number, default: 0 }
+  questionAnswerCooldown: { type: Number, default: 0 },
+  // Default instructions shown for each side quest type. Admins can
+  // customise these strings from the new instructions settings screen.
+  sideQuestInstructions: {
+    bonus: {
+      type: String,
+      default: 'Scan the correct QR code to complete this bonus quest.'
+    },
+    meetup: {
+      type: String,
+      default: 'Meet at the specified location and snap a group photo.'
+    },
+    photo: {
+      type: String,
+      default: 'Upload a photo proving you completed the challenge.'
+    },
+    race: {
+      type: String,
+      default:
+        'Race against the clock! Upload your proof before the timer expires.'
+    },
+    passcode: {
+      type: String,
+      default: 'Enter the secret passcode along with your photo.'
+    },
+    trivia: {
+      type: String,
+      default:
+        'Answer the trivia question correctly then upload your photo evidence.'
+    }
+  }
 });
 
 module.exports = mongoose.model('Settings', settingsSchema);


### PR DESCRIPTION
## Summary
- allow default instructions for each sidequest type in Settings model
- expose new admin page to edit these instructions
- display default instructions and timers in sidequest pages
- link instructions page from the sidebar

## Testing
- `npm --prefix server install`
- `npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_6863be3e30b4832891345a0f455cf71c