### PR TITLE
Add submission management for sidequests

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,6 +25,8 @@ import SideQuestStatusPage from './pages/SideQuestStatusPage';
 import NewSideQuestPage from './pages/NewSideQuestPage';
 import CreateSideQuestPage from './pages/CreateSideQuestPage';
 import SideQuestEditPage from './pages/SideQuestEditPage';
+import SideQuestSubmissionsPage from './pages/SideQuestSubmissionsPage';
+import MySideQuestSubmissionPage from './pages/MySideQuestSubmissionPage';
 import AdminCluesPage from './pages/AdminCluesPage';
 import AdminQuestionsPage from './pages/AdminQuestionsPage';
 import AdminSideQuestsPage from './pages/AdminSideQuestsPage';
@@ -231,6 +233,22 @@ export default function App() {
                 element={
                   <AuthRoute>
                     <SideQuestEditPage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/sidequests/:id/submissions"
+                element={
+                  <AuthRoute>
+                    <SideQuestSubmissionsPage />
+                  </AuthRoute>
+                }
+              />
+              <Route
+                path="/sidequests/:id/my-submission"
+                element={
+                  <AuthRoute>
+                    <MySideQuestSubmissionPage />
                   </AuthRoute>
                 }
               />

--- a/client/src/pages/MySideQuestSubmissionPage.js
+++ b/client/src/pages/MySideQuestSubmissionPage.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  fetchSideQuest,
+  fetchMySideQuestSubmission,
+  updateMySideQuestSubmission
+} from '../services/api';
+import PhotoUploader from '../components/PhotoUploader';
+
+// Allows a team to replace their submission for a side quest
+export default function MySideQuestSubmissionPage() {
+  const { id } = useParams();
+  const [quest, setQuest] = useState(null); // side quest details
+  const [submission, setSubmission] = useState(null); // existing media
+  const [loading, setLoading] = useState(true); // loading indicator
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [qRes, sRes] = await Promise.all([
+          fetchSideQuest(id),
+          fetchMySideQuestSubmission(id)
+        ]);
+        setQuest(qRes.data);
+        setSubmission(sRes.data);
+      } catch (err) {
+        if (err.response?.status !== 404) console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (id) load();
+  }, [id]);
+
+  const handleUpload = async (formData) => {
+    try {
+      const { data } = await updateMySideQuestSubmission(id, formData);
+      setSubmission(data);
+      alert('Submission updated');
+    } catch (err) {
+      console.error(err);
+      alert(err.response?.data?.message || 'Upload failed');
+    }
+  };
+
+  if (loading) return <p>Loading…</p>;
+  if (!quest) return <p>Side quest not found.</p>;
+
+  return (
+    <div>
+      <h2>Edit Submission for {quest.title}</h2>
+      {submission && (
+        <div style={{ marginBottom: '1rem' }}>
+          {submission.url.match(/\.(mp4|mov|avi)$/i) ? (
+            <video src={submission.url} width={200} controls />
+          ) : (
+            <img src={submission.url} alt="current" width={200} />
+          )}
+        </div>
+      )}
+      <PhotoUploader
+        label="Replace Media"
+        requiredMediaType={quest.requiredMediaType}
+        onUpload={handleUpload}
+      />
+    </div>
+  );
+}

--- a/client/src/pages/SideQuestSubmissionsPage.js
+++ b/client/src/pages/SideQuestSubmissionsPage.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { fetchSideQuest, fetchSideQuestSubmissions } from '../services/api';
+import RogueItem from '../components/RogueItem';
+
+// Display all media submissions for a side quest
+export default function SideQuestSubmissionsPage() {
+  const { id } = useParams();
+  const [quest, setQuest] = useState(null); // side quest details
+  const [media, setMedia] = useState([]); // submission list
+  const [loading, setLoading] = useState(true); // loading indicator
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [qRes, mRes] = await Promise.all([
+          fetchSideQuest(id),
+          fetchSideQuestSubmissions(id)
+        ]);
+        setQuest(qRes.data);
+        setMedia(mRes.data);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    if (id) load();
+  }, [id]);
+
+  if (loading) return <p>Loading…</p>;
+  if (!quest) return <p>Side quest not found.</p>;
+
+  return (
+    <div>
+      <h2>Submissions for {quest.title}</h2>
+      <div className="rogue-grid">
+        {media.map((m) => (
+          <RogueItem key={m._id} media={m} showInfo={false} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -81,6 +81,14 @@ export const submitSideQuest = (id, data) =>
   axios.post(`/api/sidequests/${id}/submit`, data, {
     headers: { 'Content-Type': 'multipart/form-data' }
   });
+export const fetchSideQuestSubmissions = (id) =>
+  axios.get(`/api/sidequests/${id}/submissions`);
+export const fetchMySideQuestSubmission = (id) =>
+  axios.get(`/api/sidequests/${id}/submission`);
+export const updateMySideQuestSubmission = (id, data) =>
+  axios.put(`/api/sidequests/${id}/submission`, data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
 // Retrieve rogues gallery items with optional sorting.
 // sort can be 'newest', 'hottest' or 'best'.
 export const fetchRoguesGallery = (sort = 'newest') =>

--- a/server/controllers/progressController.js
+++ b/server/controllers/progressController.js
@@ -175,6 +175,7 @@ exports.getItemScanStats = async (req, res) => {
           // Display creator info when available
           setBy: item.setBy || '',
           teamName: item.team ? item.team.name : '',
+          teamId: item.team ? item.team._id : '',
           // Used by the client to know when to link to the item page
           scanned: !!scannedBy
         };

--- a/server/routes/sidequests.js
+++ b/server/routes/sidequests.js
@@ -7,7 +7,10 @@ const {
   createSideQuest,
   submitSideQuestProof,
   updateSideQuest,
-  deleteSideQuest
+  deleteSideQuest,
+  getSideQuestSubmissions,
+  getMySideQuestSubmission,
+  updateMySideQuestSubmission
 } = require('../controllers/sideQuestController');
 
 // Authenticated player endpoint for active quests
@@ -23,6 +26,18 @@ router.post(
   auth,
   upload.fields([{ name: 'sideQuestMedia', maxCount: 1 }]),
   submitSideQuestProof
+);
+
+// List submissions for a quest
+router.get('/:id/submissions', auth, getSideQuestSubmissions);
+// Retrieve the current team's submission
+router.get('/:id/submission', auth, getMySideQuestSubmission);
+// Replace the current team's submission
+router.put(
+  '/:id/submission',
+  auth,
+  upload.fields([{ name: 'sideQuestMedia', maxCount: 1 }]),
+  updateMySideQuestSubmission
 );
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- extend progress API to include side quest teamId
- support listing and editing side quest submissions on the server
- expose submission APIs to the client
- show action links on the side quest progress table
- add pages for viewing all submissions and editing the team's submission

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6863bef110048328ac659d58b56d6fe3