### PR TITLE
Fix ESLint rule error and improve instructions page

### DIFF
--- a/client/src/pages/AdminInstructionsPage.js
+++ b/client/src/pages/AdminInstructionsPage.js
@@ -5,14 +5,18 @@ import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
 // side quest type. The values are stored on the Settings document
 // under `sideQuestInstructions`.
 export default function AdminInstructionsPage() {
-  const [instr, setInstr] = useState({
+  // Default instruction text for each quest type. This is used both for
+  // initializing state and as a fallback if no settings exist on the server.
+  const initialInstr = {
     bonus: '',
     meetup: '',
     photo: '',
     race: '',
     passcode: '',
     trivia: ''
-  });
+  };
+
+  const [instr, setInstr] = useState(initialInstr);
 
   const [loading, setLoading] = useState(true);
 
@@ -20,7 +24,8 @@ export default function AdminInstructionsPage() {
     const load = async () => {
       try {
         const { data } = await fetchSettingsAdmin();
-        setInstr(data.sideQuestInstructions || instr);
+        // Use the default values if the server hasn't stored any yet
+        setInstr(data.sideQuestInstructions || initialInstr);
       } catch (err) {
         console.error(err);
       } finally {
@@ -28,8 +33,7 @@ export default function AdminInstructionsPage() {
       }
     };
     load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, []); // run once on mount
 
   // Save the updated instructions back to the server
   const handleSave = async () => {
@@ -45,7 +49,8 @@ export default function AdminInstructionsPage() {
 
   if (loading) return <p>Loading…</p>;
 
-  // Helper to render a labelled textarea for a quest type
+  // Helper component to render a labelled textarea for one quest type. Updates
+  // the corresponding field in state when edited.
   const Field = ({ type, label }) => (
     <label style={{ display: 'block', marginBottom: '1rem' }}>
       {label}:
@@ -60,6 +65,7 @@ export default function AdminInstructionsPage() {
   return (
     <div className="card spaced-card" style={{ maxWidth: '600px' }}>
       <h2>Side Quest Instructions</h2>
+      {/* When the form is submitted, persist the instructions to the server */}
       <form
         onSubmit={(e) => {
           e.preventDefault();


### PR DESCRIPTION
## Summary
- avoid referring to `react-hooks/exhaustive-deps` by adjusting the side quest instructions page
- document default instructions and field component
- add note when persisting instructions in the form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866438d7a188328be6621543eb02f85