### PR TITLE
Fix onboarding UI and wall preview

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -154,7 +154,10 @@ export default function Navbar() {
                   background: 'var(--primary-color)',
                   color: 'var(--text-color)',
                   padding: '0.5rem',
-                  listStyle: 'none'
+                  listStyle: 'none',
+                  fontFamily: 'inherit',
+                  whiteSpace: 'nowrap',
+                  minWidth: '180px'
                 }}
               >
                 <li>

--- a/client/src/components/Wall.js
+++ b/client/src/components/Wall.js
@@ -8,6 +8,7 @@ export default function Wall({ type, id, onNewComment }) {
   const [comments, setComments] = useState([]);
   const [text, setText] = useState('');
   const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState('');
 
   // Load comments whenever type or id changes
   useEffect(() => {
@@ -35,6 +36,7 @@ export default function Wall({ type, id, onNewComment }) {
       if (onNewComment) onNewComment();
       setText('');
       setFile(null);
+      setPreview('');
     } catch (err) {
       alert(err.response?.data?.message || 'Error posting comment');
     }
@@ -51,7 +53,21 @@ export default function Wall({ type, id, onNewComment }) {
           rows={3}
           style={{ width: '100%', marginBottom: '0.5rem' }}
         />
-        <ImageSelector onSelect={(f) => setFile(f)} />
+        <ImageSelector
+          onSelect={(f) => {
+            setFile(f);
+            const reader = new FileReader();
+            reader.onloadend = () => setPreview(reader.result);
+            reader.readAsDataURL(f);
+          }}
+        />
+        {preview && (
+          <img
+            src={preview}
+            alt="preview"
+            style={{ width: 80, height: 80, objectFit: 'cover', marginBottom: '0.5rem' }}
+          />
+        )}
         <button type="submit">Post</button>
       </form>
       <div>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -86,11 +86,6 @@ export default function Dashboard() {
       <div className="card">
         <h3>Team: {team.name}</h3>
         <p>
-          <strong>Colour Scheme:</strong>{' '}
-          <span style={{ color: team.colourScheme.primary }}>{team.colourScheme.primary}</span> /{' '}
-          <span style={{ color: team.colourScheme.secondary }}>{team.colourScheme.secondary}</span>
-        </p>
-        <p>
           <strong>Current Clue:</strong> {`Clue ${team.currentClue}`}
         </p>
         <p>

--- a/client/src/pages/ItemTablePage.js
+++ b/client/src/pages/ItemTablePage.js
@@ -28,15 +28,20 @@ export default function ItemTablePage({ type, titlePrefix }) {
 
   if (loading) return <p>Loading…</p>;
 
+  const remaining = items.filter((i) => !i.scanned).length;
+
   // List of all game items in a card
   return (
     <div className="card spaced-card">
       <h2>{titlePrefix}</h2>
+      <p>
+        Your team has found the following {titlePrefix.toLowerCase()} - {remaining}{' '}
+        {titlePrefix.toLowerCase()} remaining!
+      </p>
       <table>
         <thead>
           <tr>
             <th>Title</th>
-            <th>Scanned By</th>
             <th>Status</th>
             <th>Last Scanned By</th>
             <th>Total Scans</th>
@@ -59,7 +64,6 @@ export default function ItemTablePage({ type, titlePrefix }) {
                   it.title
                 )}
               </td>
-              <td>{it.scannedBy || '-'}</td>
               <td>{it.status}</td>
               <td>{it.lastScannedBy || '-'}</td>
               <td>{it.totalScans}</td>

--- a/client/src/pages/SignupPage.js
+++ b/client/src/pages/SignupPage.js
@@ -9,25 +9,40 @@ import ProfilePic from '../components/ProfilePic';
 export default function SignupPage() {
   const { state } = useLocation();
   const navigate = useNavigate();
-  // Expect first and last names passed from the WelcomePage
-  const { firstName, lastName, next } = state || {};
+  // Expect first and last names plus optional selfie preview
+  const { firstName, lastName, next, selfiePreview } = state || {};
 
   const [teams, setTeams] = useState([]);
   const [leaderNames, setLeaderNames] = useState({});
+  const [showJoinInput, setShowJoinInput] = useState({});
   const [selfieFile, setSelfieFile] = useState(null);
+  const [selfieUrl, setSelfieUrl] = useState(selfiePreview || '');
   const [teamName, setTeamName] = useState('');
   const [teamPhotoFile, setTeamPhotoFile] = useState(null);
+  const [tab, setTab] = useState('existing');
 
   useEffect(() => {
     // Fetch the public team roster for display
     fetchTeamsPublic().then(({ data }) => setTeams(data));
   }, []);
 
+  const handleSelfieSelect = (file) => {
+    setSelfieFile(file);
+    const reader = new FileReader();
+    reader.onloadend = () => setSelfieUrl(reader.result);
+    reader.readAsDataURL(file);
+  };
+
   // Generic handler for joining an existing team
-  const joinTeam = async (leaderLastName) => {
-    if (!selfieFile) {
-      return alert('Please select a profile picture.');
+  const joinTeam = async (id) => {
+    if (!showJoinInput[id]) {
+      setShowJoinInput({ ...showJoinInput, [id]: true });
+      return;
     }
+    if (!selfieFile) return alert('Please select a profile picture.');
+    const leaderLastName = leaderNames[id] || '';
+    if (!leaderLastName) return alert('Please enter the leader\'s last name.');
+
     const form = new FormData();
     form.append('firstName', firstName);
     form.append('lastName', lastName);
@@ -37,7 +52,7 @@ export default function SignupPage() {
     try {
       const { data } = await onboard(form);
       localStorage.setItem('token', data.token);
-      navigate(next || '/profile');
+      navigate(next || '/roguery');
     } catch (err) {
       alert(err.response?.data?.message || 'Unable to join team');
     }
@@ -59,7 +74,7 @@ export default function SignupPage() {
     try {
       const { data } = await onboard(form);
       localStorage.setItem('token', data.token);
-      navigate(next || '/profile');
+      navigate(next || '/roguery');
     } catch (err) {
       alert(err.response?.data?.message || 'Unable to create team');
     }
@@ -68,41 +83,80 @@ export default function SignupPage() {
   return (
     <div className="card" style={{ maxWidth: 600, margin: '2rem auto' }}>
       <h2>Choose a Team</h2>
-      {/* All players must provide a selfie before they can join or create a team */}
+      <p>Upload a selfie then join an existing team or create your own.</p>
       <label>Your Selfie:</label>
-      <ProfilePic avatarUrl="" onFileSelect={(file) => setSelfieFile(file)} />
-      {teams.map((team) => (
-        <div key={team._id} style={{ borderBottom: '1px solid #ccc', padding: '1rem 0' }}>
-          {team.photoUrl && (
-            <img src={team.photoUrl} alt="team" style={{ width: 80, height: 80, objectFit: 'cover' }} />
-          )}
-          <div>
-            {team.members.map((m) => (
-              <span key={m.name} style={{ marginRight: '0.5rem' }}>{m.name.split(' ')[0]}</span>
+      <ProfilePic avatarUrl={selfieUrl} onFileSelect={handleSelfieSelect} />
+
+      <div style={{ display: 'flex', margin: '1rem 0' }}>
+        <button
+          type="button"
+          className="btn-mr"
+          onClick={() => setTab('existing')}
+          style={{ background: tab === 'existing' ? 'var(--secondary-color)' : 'var(--primary-color)' }}
+        >
+          Choose Existing Team
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('new')}
+          style={{ background: tab === 'new' ? 'var(--secondary-color)' : 'var(--primary-color)' }}
+        >
+          Create New Team
+        </button>
+      </div>
+
+      {tab === 'existing' ? (
+        <table>
+          <thead>
+            <tr>
+              <th>Team</th>
+              <th>Members</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {teams.map((team) => (
+              <tr key={team._id}>
+                <td>
+                  {team.photoUrl && (
+                    <img src={team.photoUrl} alt="team" style={{ width: 50, height: 50, objectFit: 'cover' }} />
+                  )}{' '}
+                  {team.name}
+                </td>
+                <td>{team.members.map((m) => m.name.split(' ')[0]).join(', ')}</td>
+                <td>
+                  {showJoinInput[team._id] && (
+                    <input
+                      type="text"
+                      placeholder="Leader last name"
+                      value={leaderNames[team._id] || ''}
+                      onChange={(e) =>
+                        setLeaderNames({ ...leaderNames, [team._id]: e.target.value })
+                      }
+                      style={{ marginRight: '0.5rem' }}
+                    />
+                  )}
+                  <button onClick={() => joinTeam(team._id)}>
+                    {showJoinInput[team._id] ? 'Confirm' : 'Join Team'}
+                  </button>
+                </td>
+              </tr>
             ))}
-          </div>
+          </tbody>
+        </table>
+      ) : (
+        <div>
           <input
             type="text"
-            placeholder="Leader last name"
-            value={leaderNames[team._id] || ''}
-            onChange={(e) => setLeaderNames({ ...leaderNames, [team._id]: e.target.value })}
-            style={{ marginRight: '0.5rem' }}
+            placeholder="Team Name"
+            value={teamName}
+            onChange={(e) => setTeamName(e.target.value)}
           />
-        <button onClick={() => joinTeam(leaderNames[team._id] || '')}>Join Team</button>
-      </div>
-      ))}
-      <div style={{ marginTop: '1rem' }}>
-        <h3>Create New Team</h3>
-        <input
-          type="text"
-          placeholder="Team Name"
-          value={teamName}
-          onChange={(e) => setTeamName(e.target.value)}
-        />
-        <label>Team Photo:</label>
-        <ProfilePic avatarUrl="" onFileSelect={(file) => setTeamPhotoFile(file)} />
-        <button onClick={createTeam}>Create New Team</button>
-      </div>
+          <label>Team Photo:</label>
+          <ProfilePic avatarUrl="" onFileSelect={(file) => setTeamPhotoFile(file)} />
+          <button onClick={createTeam}>Create New Team</button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve welcome page input layout and validation
- refactor sign up flow with tabs and selfie preview
- show preview thumbnails on wall comments
- clean up navbar dropdown styles
- remove colour scheme from dashboard
- tweak item progress table headers

## Testing
- `npm test --silent --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_68664ba1f7188328bde9da7f86bebfa2