### PR TITLE
Improve WelcomePage tab UI

### DIFF
--- a/client/src/pages/WelcomePage.js
+++ b/client/src/pages/WelcomePage.js
@@ -66,23 +66,19 @@ export default function WelcomePage() {
   return (
     <div className="card" style={{ maxWidth: 400, margin: '2rem auto' }}>
       <h2>Welcome</h2>
-      <div style={{ display: 'flex', marginBottom: '1rem' }}>
+      {/* Tab controls above the form; active tab is styled via CSS */}
+      <div className="tab-container">
         <button
           type="button"
-          className="btn-mr"
+          className={`tab ${tab === 'login' ? 'active' : ''}`}
           onClick={() => setTab('login')}
-          style={{
-            background: tab === 'login' ? 'var(--secondary-color)' : 'var(--primary-color)'
-          }}
         >
           Log In
         </button>
         <button
           type="button"
+          className={`tab ${tab === 'signup' ? 'active' : ''}`}
           onClick={() => setTab('signup')}
-          style={{
-            background: tab === 'signup' ? 'var(--secondary-color)' : 'var(--primary-color)'
-          }}
         >
           Sign Up
         </button>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -261,6 +261,36 @@ form label {
 }
 
 /*
+ * Tabs used on the welcome screen. Each tab button has no shadow so it
+ * blends with the container. The active tab is highlighted and connects
+ * visually with the card below.
+ */
+.tab-container {
+  display: flex;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid var(--secondary-color);
+}
+
+.tab {
+  flex: 1;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  background: var(--primary-color);
+  border: none;
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+  color: var(--text-color);
+  cursor: pointer;
+  box-shadow: none;
+  border-bottom: 2px solid transparent;
+}
+
+.tab.active {
+  background: var(--background-color);
+  border-bottom-color: var(--background-color);
+  font-weight: 600;
+}
+
+/*
  * Generic vertical list layout used for player and team profiles.
  * Each row is flex-based so content stacks nicely on small screens.
  */


### PR DESCRIPTION
## Summary
- style the login/signup tabs like real tabs
- show active tab clearly on the welcome page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866506402988328a12ce287fae5262d