### PR TITLE
Fix menu font mismatch

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -155,6 +155,7 @@ export default function Navbar() {
                   color: 'var(--text-color)',
                   padding: '0.5rem',
                   listStyle: 'none',
+                  // Inherit the admin-selected font for dropdown items
                   fontFamily: 'inherit',
                   whiteSpace: 'nowrap',
                   minWidth: '180px'

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -91,6 +91,8 @@ img {
   border: none;
   cursor: pointer;
   font-size: 1rem;
+  /* Use admin-selected font for all navbar items */
+  font-family: var(--font-family);
 }
 
 /* Make the right-side list horizontal & reset bullets */
@@ -167,6 +169,8 @@ button {
   box-shadow: 4px 4px 8px var(--shadow-dark),
     -4px -4px 8px var(--shadow-light);
   transition: box-shadow 0.2s;
+  /* Inherit admin-selected font so buttons match the rest of the UI */
+  font-family: var(--font-family);
 }
 
 button:hover {


### PR DESCRIPTION
## Summary
- inherit admin font in navbar menu items
- use theme font on all buttons
- document dropdown style

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6866d2c7484c83288a3264343a6285f2