### PR TITLE
Improve mobile progress views

### DIFF
--- a/client/src/pages/ItemTablePage.js
+++ b/client/src/pages/ItemTablePage.js
@@ -1,22 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchProgress, fetchMe } from '../services/api';
+import { fetchProgress } from '../services/api';
 
 // Generic table listing progress for clues, questions or side quests
 export default function ItemTablePage({ type, titlePrefix }) {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [team, setTeam] = useState(null); // current player's team info
 
   useEffect(() => {
     const load = async () => {
       try {
-        const [progRes, meRes] = await Promise.all([
-          fetchProgress(type),
-          type === 'sidequest' ? fetchMe() : Promise.resolve({ data: null })
-        ]);
-        setItems(progRes.data);
-        if (type === 'sidequest') setTeam(meRes.data.team);
+        const { data } = await fetchProgress(type);
+        setItems(data);
       } catch (err) {
         console.error(err);
       } finally {
@@ -43,51 +38,19 @@ export default function ItemTablePage({ type, titlePrefix }) {
           <tr>
             <th>Title</th>
             <th>Status</th>
-            <th>Last Scanned By</th>
-            <th>Total Scans</th>
-            {type === 'sidequest' && (
-              <>
-                <th>Set By</th>
-                <th>Team</th>
-                <th>Actions</th>
-              </>
-            )}
           </tr>
         </thead>
         <tbody>
           {items.map((it) => (
             <tr key={it._id}>
-              <td>
+              <td data-label="Title">
                 {it.scanned ? (
                   <Link to={`/${type === 'sidequest' ? 'sidequest' : type}/${it._id}`}>{it.title}</Link>
                 ) : (
                   it.title
                 )}
               </td>
-              <td>{it.status}</td>
-              <td>{it.lastScannedBy || '-'}</td>
-              <td>{it.totalScans}</td>
-              {type === 'sidequest' && (
-                <>
-                  <td>{it.setBy || '-'}</td>
-                  <td>{it.teamName || '-'}</td>
-                  <td>
-                    <Link to={`/sidequests/${it._id}/submissions`}>View submissions</Link>
-                    {it.status === 'DONE!' && (
-                      <>
-                        {' '}
-                        <Link to={`/sidequests/${it._id}/my-submission`}>Edit my submission</Link>
-                      </>
-                    )}
-                    {team && team._id === it.teamId && (
-                      <>
-                        {' '}
-                        <Link to={`/sidequests/${it._id}/edit`}>Edit sidequest</Link>
-                      </>
-                    )}
-                  </td>
-                </>
-              )}
+              <td data-label="Status">{it.status}</td>
             </tr>
           ))}
         </tbody>

--- a/client/src/pages/QuestionPage.js
+++ b/client/src/pages/QuestionPage.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { fetchClue, submitAnswer } from '../services/api';
+import { fetchClue, submitAnswer, fetchProgressItem } from '../services/api';
 
 // Question view for the single active game
 export default function QuestionPage() {
@@ -11,6 +11,7 @@ export default function QuestionPage() {
   const [loading, setLoading] = useState(true);
   const [answer, setAnswer] = useState('');
   const [feedback, setFeedback] = useState(null);
+  const [stats, setStats] = useState(null); // progress details
 
   useEffect(() => {
     const loadClue = async () => {
@@ -27,6 +28,10 @@ export default function QuestionPage() {
     };
     if (clueId) {
       loadClue();
+      // also fetch scan stats for this clue
+      fetchProgressItem('clue', clueId)
+        .then((data) => setStats(data))
+        .catch((err) => console.error(err));
     }
   }, [clueId]);
 
@@ -123,6 +128,12 @@ export default function QuestionPage() {
           >
             {feedback}
           </p>
+        )}
+        {stats && (
+          <div style={{ marginTop: '1rem', fontSize: '0.9rem' }}>
+            <p>Last scanned by: {stats.lastScannedBy || '-'}</p>
+            <p>Total scans: {stats.totalScans}</p>
+          </div>
         )}
       </div>
     </div>

--- a/client/src/pages/QuestionPlayPage.js
+++ b/client/src/pages/QuestionPlayPage.js
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { fetchQuestion, submitQuestionAnswer } from "../services/api";
+import {
+  fetchQuestion,
+  submitQuestionAnswer,
+  fetchProgressItem
+} from "../services/api";
 
 // Display a single trivia question for players
 export default function QuestionPlayPage() {
@@ -12,6 +16,7 @@ export default function QuestionPlayPage() {
   const [lockedUntil, setLockedUntil] = useState(null);
   const [saving, setSaving] = useState(false);
   const [timeLeft, setTimeLeft] = useState(0); // seconds remaining on cooldown
+  const [stats, setStats] = useState(null); // progress details
 
   useEffect(() => {
     const load = async () => {
@@ -28,7 +33,12 @@ export default function QuestionPlayPage() {
         setLoading(false);
       }
     };
-    if (id) load();
+    if (id) {
+      load();
+      fetchProgressItem("question", id)
+        .then((data) => setStats(data))
+        .catch((err) => console.error(err));
+    }
   }, [id]);
 
   // Update countdown timer whenever the lock expiry changes
@@ -111,6 +121,12 @@ export default function QuestionPlayPage() {
           </form>
         )}
       </div>
+      {stats && (
+        <div style={{ marginTop: "1rem", fontSize: "0.9rem" }}>
+          <p>Last scanned by: {stats.lastScannedBy || '-'}</p>
+          <p>Total scans: {stats.totalScans}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/SideQuestDetailPage.js
+++ b/client/src/pages/SideQuestDetailPage.js
@@ -1,6 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchSideQuest, submitSideQuest, fetchSettings } from '../services/api';
+import {
+  fetchSideQuest,
+  submitSideQuest,
+  fetchSettings,
+  fetchProgressItem
+} from '../services/api';
 import PhotoUploader from '../components/PhotoUploader';
 
 // Detailed view for a single side quest with upload option
@@ -12,6 +17,7 @@ export default function SideQuestDetailPage() {
   const [answer, setAnswer] = useState(''); // selected answer for trivia quests
   const [defaults, setDefaults] = useState({}); // default instructions per type
   const [timeLeft, setTimeLeft] = useState(null); // countdown for timed quests
+  const [stats, setStats] = useState(null); // progress details
 
   useEffect(() => {
     const load = async () => {
@@ -32,6 +38,15 @@ export default function SideQuestDetailPage() {
       }
     };
     if (id) load();
+    const loadStats = async () => {
+      try {
+        const data = await fetchProgressItem('sidequest', id);
+        setStats(data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    if (id) loadStats();
   }, [id]);
 
   const handleUpload = async (formData) => {
@@ -116,6 +131,14 @@ export default function SideQuestDetailPage() {
             onUpload={handleUpload}
           />
         </div>
+        {stats && (
+          <div style={{ marginTop: '1rem', fontSize: '0.9rem' }}>
+            <p>Last scanned by: {stats.lastScannedBy || '-'}</p>
+            <p>Total scans: {stats.totalScans}</p>
+            {stats.setBy && <p>Set by: {stats.setBy}</p>}
+            {stats.teamName && <p>Team: {stats.teamName}</p>}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -129,6 +129,12 @@ export const fetchAdminScoreboard = () => axios.get('/api/admin/scoreboard');
 // Player progress tables
 export const fetchProgress = (type) => axios.get(`/api/progress/${type}`);
 
+// Retrieve progress details for a single item by filtering the list
+export const fetchProgressItem = async (type, id) => {
+  const { data } = await fetchProgress(type);
+  return data.find((it) => it._id === id);
+};
+
 
 // Admin CRUD for clues
 export const fetchClues = () => axios.get('/api/admin/clues');


### PR DESCRIPTION
## Summary
- simplify item tables to show only title and status
- expose `fetchProgressItem` helper
- display scan stats on clue, question and side quest detail pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d472e5208328989a762bef563729