### PR TITLE
Add expandable QR code component

### DIFF
--- a/client/src/components/ExpandableQr.js
+++ b/client/src/components/ExpandableQr.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+/**
+ * Display a small QR code thumbnail that can be clicked to view a larger
+ * version in a modal overlay. The modal uses the global `.modal-overlay` and
+ * `.modal-content` styles defined in `index.css`.
+ */
+export default function ExpandableQr({ data, size = 50, max = 400 }) {
+  const [open, setOpen] = useState(false); // track modal visibility
+
+  if (!data) return null; // nothing to show if no QR data provided
+
+  return (
+    <>
+      {/* Small preview image shown inline */}
+      <img
+        src={data}
+        alt="QR"
+        style={{ width: size, cursor: 'pointer' }}
+        onClick={() => setOpen(true)}
+      />
+
+      {/* Full-size modal, appears when `open` is true */}
+      {open && (
+        <div className="modal-overlay" onClick={() => setOpen(false)}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <img src={data} alt="QR Code" style={{ width: '80vw', maxWidth: max }} />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/pages/AdminCluesPage.js
+++ b/client/src/pages/AdminCluesPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ImageSelector from '../components/ImageSelector';
+import ExpandableQr from '../components/ExpandableQr';
 import {
   fetchClues,
   createClueAdmin,
@@ -139,7 +140,7 @@ export default function AdminCluesPage() {
                   </td>
                   <td>
                     {c.qrCodeData ? (
-                      <img src={c.qrCodeData} alt="QR" width={50} />
+                      <ExpandableQr data={c.qrCodeData} size={50} />
                     ) : (
                       '-'
                     )}
@@ -163,7 +164,7 @@ export default function AdminCluesPage() {
                   <td>{c.correctAnswer}</td>
                   <td>
                     {c.qrCodeData ? (
-                      <img src={c.qrCodeData} alt="QR" width={50} />
+                      <ExpandableQr data={c.qrCodeData} size={50} />
                     ) : (
                       '-'
                     )}

--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ImageSelector from '../components/ImageSelector';
+import ExpandableQr from '../components/ExpandableQr';
 import {
   fetchQuestions,
   createQuestion,
@@ -144,7 +145,7 @@ export default function AdminQuestionsPage() {
                     {q.imageUrl ? <img src={q.imageUrl} alt={q.title} width={50} /> : '-'}
                   </td>
                   <td>
-                    {q.qrCodeData ? <img src={q.qrCodeData} alt="QR" width={50} /> : '-'}
+                    {q.qrCodeData ? <ExpandableQr data={q.qrCodeData} size={50} /> : '-'}
                   </td>
                   <td>
                     <button onClick={() => handleSave(q._id)}>Save</button>
@@ -159,7 +160,7 @@ export default function AdminQuestionsPage() {
                   <td>{q.correctAnswer || '-'}</td>
                   <td>{q.notes}</td>
                   <td>{q.imageUrl ? <img src={q.imageUrl} alt={q.title} width={50} /> : '-'}</td>
-                  <td>{q.qrCodeData ? <img src={q.qrCodeData} alt="QR" width={50} /> : '-'}</td>
+                  <td>{q.qrCodeData ? <ExpandableQr data={q.qrCodeData} size={50} /> : '-'}</td>
                   <td>
                     <button
                       onClick={() => {

--- a/client/src/pages/AdminSideQuestsPage.js
+++ b/client/src/pages/AdminSideQuestsPage.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ImageSelector from '../components/ImageSelector';
+import ExpandableQr from '../components/ExpandableQr';
 import {
   fetchSideQuestsAdmin,
   createSideQuestAdmin,
@@ -146,7 +147,7 @@ export default function AdminSideQuestsPage() {
                   </td>
                   <td>
                     {q.qrCodeData ? (
-                      <img src={q.qrCodeData} alt="QR" width={50} />
+                      <ExpandableQr data={q.qrCodeData} size={50} />
                     ) : (
                       '-'
                     )}
@@ -171,7 +172,7 @@ export default function AdminSideQuestsPage() {
                   <td>{q.timeLimitSeconds || '-'}</td>
                   <td>
                     {q.qrCodeData ? (
-                      <img src={q.qrCodeData} alt="QR" width={50} />
+                      <ExpandableQr data={q.qrCodeData} size={50} />
                     ) : (
                       '-'
                     )}

--- a/client/src/pages/QuestionPage.js
+++ b/client/src/pages/QuestionPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { fetchClue, submitAnswer, fetchProgressItem } from '../services/api';
+import ExpandableQr from '../components/ExpandableQr';
 
 // Question view for the single active game
 export default function QuestionPage() {
@@ -83,7 +84,7 @@ export default function QuestionPage() {
         {clue.qrCodeData && (
           <div style={{ marginTop: '1rem' }}>
             <p>Scan this QR code to proceed:</p>
-            <img src={clue.qrCodeData} alt="QR Code" />
+            <ExpandableQr data={clue.qrCodeData} size={100} max={500} />
           </div>
         )}
         <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>

--- a/client/src/pages/SideQuestEditPage.js
+++ b/client/src/pages/SideQuestEditPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
+import ExpandableQr from '../components/ExpandableQr';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   fetchSideQuest,
@@ -203,7 +204,7 @@ export default function SideQuestEditPage() {
       </div>
       {quest.qrCodeData && (
         <div style={{ marginBottom: '1rem' }}>
-          <img src={quest.qrCodeData} alt="QR" width={120} />
+          <ExpandableQr data={quest.qrCodeData} size={120} />
         </div>
       )}
       <button onClick={handleSave}>Save</button>


### PR DESCRIPTION
## Summary
- implement reusable `ExpandableQr` component
- expand all QR code displays on admin and gameplay pages
- update imports and docs

## Testing
- `npm install` in `server`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d6b38d008328b0e98b0b8593fa09