### PR TITLE
Add dashboard greeting and gamemaster crib sheet

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -38,6 +38,7 @@ import AdminInstructionsPage from './pages/AdminInstructionsPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
+import AdminCribSheetPage from './pages/AdminCribSheetPage';
 import QrScanButton from './components/QrScanButton';
 import InstallPrompt from './components/InstallPrompt';
 import NotificationHandler from './components/NotificationHandler';
@@ -271,6 +272,14 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminDashboardPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/cribsheet"
+                element={
+                  <AdminRoute>
+                    <AdminCribSheetPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -98,15 +98,31 @@ export default function Navbar() {
         </button>
 
         {theme.logoUrl ? (
-          <Link to="/">
-            <img
-              src={theme.logoUrl}
-              alt="Logo"
-              style={{ height: '40px' }}
-            />
+          <Link
+            /* Clicking the logo should take the user to their dashboard.
+               Admin users without a player token go to the admin dashboard. */
+            to={
+              adminToken && !token
+                ? '/admin/dashboard'
+                : token
+                ? '/dashboard'
+                : '/'
+            }
+          >
+            <img src={theme.logoUrl} alt="Logo" style={{ height: '40px' }} />
           </Link>
         ) : (
-          <Link to="/">Treasure Hunt</Link>
+          <Link
+            to={
+              adminToken && !token
+                ? '/admin/dashboard'
+                : token
+                ? '/dashboard'
+                : '/'
+            }
+          >
+            Treasure Hunt
+          </Link>
         )}
       </div>
 

--- a/client/src/pages/AdminCluesPage.js
+++ b/client/src/pages/AdminCluesPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import ImageSelector from '../components/ImageSelector';
 import ExpandableQr from '../components/ExpandableQr';
 import {
@@ -94,6 +95,10 @@ export default function AdminCluesPage() {
   return (
     <div className="card spaced-card">
       <h2>Clues</h2>
+      {/* Link to printable overview for gamemasters */}
+      <p>
+        <Link to="/admin/cribsheet">Print Crib Sheet</Link>
+      </p>
       <table>
         <thead>
           <tr>

--- a/client/src/pages/AdminCribSheetPage.js
+++ b/client/src/pages/AdminCribSheetPage.js
@@ -1,0 +1,147 @@
+import React, { useEffect, useState } from 'react';
+import {
+  fetchClues,
+  fetchQuestions,
+  fetchSideQuestsAdmin,
+  fetchPlayers,
+  fetchTeamsAdmin
+} from '../services/api';
+
+// Printable overview for gamemasters showing all game data
+export default function AdminCribSheetPage() {
+  const [clues, setClues] = useState([]);
+  const [questions, setQuestions] = useState([]);
+  const [quests, setQuests] = useState([]);
+  const [players, setPlayers] = useState([]);
+  const [teams, setTeams] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [cRes, qRes, sqRes, pRes, tRes] = await Promise.all([
+          fetchClues(),
+          fetchQuestions(),
+          fetchSideQuestsAdmin(),
+          fetchPlayers(),
+          fetchTeamsAdmin()
+        ]);
+        setClues(cRes.data);
+        setQuestions(qRes.data);
+        setQuests(sqRes.data);
+        setPlayers(pRes.data);
+        setTeams(tRes.data);
+      } catch (err) {
+        console.error('Error loading crib sheet data:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) return <p>Loading…</p>;
+
+  return (
+    <div className="card spaced-card">
+      <h2>Gamemaster Crib Sheet</h2>
+      <button onClick={() => window.print()}>Print</button>
+
+      <h3>Clues</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Text</th>
+            <th>Answer</th>
+          </tr>
+        </thead>
+        <tbody>
+          {clues.map((c) => (
+            <tr key={c._id}>
+              <td>{c.title}</td>
+              <td>{c.text}</td>
+              <td>{c.correctAnswer}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Questions</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Question</th>
+            <th>Answer</th>
+          </tr>
+        </thead>
+        <tbody>
+          {questions.map((q) => (
+            <tr key={q._id}>
+              <td>{q.title}</td>
+              <td>{q.text}</td>
+              <td>{q.correctAnswer}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Side Quests</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Text</th>
+            <th>Time Limit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {quests.map((q) => (
+            <tr key={q._id}>
+              <td>{q.title}</td>
+              <td>{q.text}</td>
+              <td>{q.timeLimitSeconds || '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Teams</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Leader</th>
+          </tr>
+        </thead>
+        <tbody>
+          {teams.map((t) => (
+            <tr key={t._id}>
+              <td>{t.name}</td>
+              <td>{t.leader ? t.leader.name : '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Players</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Team</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((p) => (
+            <tr key={p._id}>
+              <td>{p.name}</td>
+              <td>{p.team ? p.team.name : '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/pages/AdminPlayersPage.js
+++ b/client/src/pages/AdminPlayersPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { fetchPlayers, deletePlayer, createPlayer, updatePlayer } from '../services/api';
 import { fetchTeamsList } from '../services/api';
 
@@ -67,6 +68,9 @@ export default function AdminPlayersPage() {
   return (
     <div className="card spaced-card">
       <h2>Players</h2>
+      <p>
+        <Link to="/admin/cribsheet">Print Crib Sheet</Link>
+      </p>
       <table>
         <thead>
           <tr>

--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import ImageSelector from '../components/ImageSelector';
 import ExpandableQr from '../components/ExpandableQr';
 import {
@@ -92,6 +93,10 @@ export default function AdminQuestionsPage() {
   return (
     <div className="card spaced-card">
       <h2>Questions</h2>
+      {/* Quick link to a printable crib sheet */}
+      <p>
+        <Link to="/admin/cribsheet">Print Crib Sheet</Link>
+      </p>
       <table>
         <thead>
           <tr>

--- a/client/src/pages/AdminSideQuestsPage.js
+++ b/client/src/pages/AdminSideQuestsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import ImageSelector from '../components/ImageSelector';
 import ExpandableQr from '../components/ExpandableQr';
 import {
@@ -96,6 +97,10 @@ export default function AdminSideQuestsPage() {
   return (
     <div className="card spaced-card">
       <h2>Side Quests</h2>
+      {/* Access printable summary */}
+      <p>
+        <Link to="/admin/cribsheet">Print Crib Sheet</Link>
+      </p>
       <table>
         <thead>
           <tr>

--- a/client/src/pages/AdminTeamsPage.js
+++ b/client/src/pages/AdminTeamsPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import {
   fetchTeamsAdmin,
   createTeamAdmin,
@@ -118,6 +119,9 @@ export default function AdminTeamsPage() {
   return (
     <div className="card spaced-card">
       <h2>Teams</h2>
+      <p>
+        <Link to="/admin/cribsheet">Print Crib Sheet</Link>
+      </p>
       <table>
         <thead>
           <tr>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -6,7 +6,8 @@ import {
   fetchCluesPlayer,
   fetchProgress,
   fetchScoreboard,
-  fetchPlayersPublic
+  fetchPlayersPublic,
+  fetchSettings
 } from '../services/api';
 import TeamMemberForm from '../components/TeamMemberForm';
 
@@ -28,6 +29,7 @@ export default function Dashboard() {
 
   // List of player documents for linking member names to profiles
   const [players, setPlayers] = useState([]);
+  const [gameName, setGameName] = useState('Treasure Hunt');
 
   useEffect(() => {
     const load = async () => {
@@ -50,13 +52,15 @@ export default function Dashboard() {
         }
 
         // Fetch progress details
-        const [qProg, cProg, sqProg, board, playerRes] = await Promise.all([
-          fetchProgress('question'),
-          fetchProgress('clue'),
-          fetchProgress('sidequest'),
-          fetchScoreboard(),
-          fetchPlayersPublic()
-        ]);
+        const [qProg, cProg, sqProg, board, playerRes, settingsRes] =
+          await Promise.all([
+            fetchProgress('question'),
+            fetchProgress('clue'),
+            fetchProgress('sidequest'),
+            fetchScoreboard(),
+            fetchPlayersPublic(),
+            fetchSettings()
+          ]);
         setPlayers(playerRes.data);
         const teamStats = board.data.find((b) => b.teamId === teamRes.data._id);
         setProgress({
@@ -69,6 +73,7 @@ export default function Dashboard() {
           photosUploaded: teamRes.data.members.filter((m) => m.avatarUrl).length
         });
 
+        setGameName(settingsRes.data.gameName || 'Treasure Hunt');
         setLoading(false);
       } catch (err) {
         console.error(err);
@@ -92,6 +97,8 @@ export default function Dashboard() {
 
   return (
     <div>
+      {/* Greet the player with the current game name */}
+      <h1>Welcome to {gameName}!</h1>
       <h2>Dashboard</h2>
       <div className="card">
         {/* Show the team photo beside the name */}

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -625,3 +625,17 @@ tbody tr:nth-child(even) {
     -4px -4px 8px var(--shadow-light);
   cursor: pointer;
 }
+
+/* Hide navigation and extra chrome when printing the crib sheet */
+@media print {
+  .navbar,
+  .sidebar,
+  .install-prompt,
+  .qr-scan-button {
+    display: none !important;
+  }
+  .spaced-card {
+    margin: 0;
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
## Summary
- clicking the logo now goes to the dashboard
- greet players with the game name on the dashboard
- allow admins to print a crib sheet of all data
- add print link on admin CRUD pages
- hide navigation when printing

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d8635d4c83288298518d4ef7513d