### PR TITLE
Add kudos voting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project contains a React client and an Express/MongoDB server for running a
 - New "passcode" and "trivia" side quest types with in-app validation
 - Admin authentication and dashboard endpoints
 - Team colour schemes and profile management
+- Kudos voting for fun player awards
 - Installable Progressive Web App with offline support
 - Admin settings include a **master reset** to wipe all game data after typing
   `definitely` as confirmation

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,6 +19,7 @@ import RoguesGalleryPage from './pages/RoguesGalleryPage';
 import InfoPage from './pages/InfoPage';
 import HelpPage from './pages/HelpPage';
 import ScoreboardPage from './pages/ScoreboardPage';
+import KudosPage from './pages/KudosPage';
 import ClueStatusPage from './pages/ClueStatusPage';
 import QuestionStatusPage from './pages/QuestionStatusPage';
 import SideQuestStatusPage from './pages/SideQuestStatusPage';
@@ -35,6 +36,7 @@ import AdminTeamsPage from './pages/AdminTeamsPage';
 import AdminGalleryPage from './pages/AdminGalleryPage';
 import AdminSettingsPage from './pages/AdminSettingsPage';
 import AdminInstructionsPage from './pages/AdminInstructionsPage';
+import AdminKudosPage from './pages/AdminKudosPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
 import AdminDashboardPage from './pages/AdminDashboardPage';
@@ -191,6 +193,14 @@ export default function App() {
                 }
               />
               <Route
+                path="/kudos"
+                element={
+                  <AuthRoute>
+                    <KudosPage />
+                  </AuthRoute>
+                }
+              />
+              <Route
                 path="/progress/clues"
                 element={
                   <AuthRoute>
@@ -321,6 +331,14 @@ export default function App() {
                 element={
                   <AdminRoute>
                     <AdminTeamsPage />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/kudos"
+                element={
+                  <AdminRoute>
+                    <AdminKudosPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -41,6 +41,7 @@ export default function Sidebar() {
           {renderLink('/players', 'Players')}
           {renderLink('/teams', 'Teams')}
           {renderLink('/scoreboard', 'Scoreboard')}
+          {renderLink('/kudos', 'Kudos')}
           {renderLink('/roguery', 'Gallery')}
         </>
       )}
@@ -54,6 +55,7 @@ export default function Sidebar() {
           {renderLink('/admin/sidequests', 'Side Quests')}
           {renderLink('/admin/players', 'Players')}
           {renderLink('/admin/teams', 'Teams')}
+          {renderLink('/admin/kudos', 'Kudos')}
           {renderLink('/admin/gallery', 'Gallery')}
           {renderLink('/admin/settings', 'Settings')}
           {renderLink('/admin/instructions', 'Instructions')}

--- a/client/src/pages/AdminKudosPage.js
+++ b/client/src/pages/AdminKudosPage.js
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import {
+  fetchKudosAdmin,
+  createKudosCategory,
+  updateKudosCategory,
+  deleteKudosCategory
+} from '../services/api';
+
+export default function AdminKudosPage() {
+  const [cats, setCats] = useState([]);
+  const [newTitle, setNewTitle] = useState('');
+  const [editId, setEditId] = useState(null);
+  const [editTitle, setEditTitle] = useState('');
+
+  const load = async () => {
+    try {
+      const { data } = await fetchKudosAdmin();
+      setCats(data);
+    } catch (err) {
+      alert('Error loading categories');
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleCreate = async () => {
+    try {
+      await createKudosCategory({ title: newTitle });
+      setNewTitle('');
+      load();
+    } catch (err) {
+      alert('Error creating category');
+    }
+  };
+
+  const handleSave = async (id) => {
+    try {
+      await updateKudosCategory(id, { title: editTitle });
+      setEditId(null);
+      setEditTitle('');
+      load();
+    } catch (err) {
+      alert('Error updating category');
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm('Delete this category?')) return;
+    try {
+      await deleteKudosCategory(id);
+      load();
+    } catch (err) {
+      alert('Error deleting category');
+    }
+  };
+
+  return (
+    <div className="card spaced-card">
+      <h2>Kudos Titles</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cats.map((c) => (
+            <tr key={c._id}>
+              {editId === c._id ? (
+                <>
+                  <td>
+                    <input
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <button onClick={() => handleSave(c._id)}>Save</button>
+                    <button onClick={() => setEditId(null)}>Cancel</button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td>{c.title}</td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        setEditId(c._id);
+                        setEditTitle(c.title);
+                      }}
+                    >
+                      Edit
+                    </button>
+                    <button onClick={() => handleDelete(c._id)}>Delete</button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+          <tr>
+            <td>
+              <input
+                value={newTitle}
+                placeholder="New title"
+                onChange={(e) => setNewTitle(e.target.value)}
+              />
+            </td>
+            <td>
+              <button onClick={handleCreate}>Add</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/pages/HelpPage.js
+++ b/client/src/pages/HelpPage.js
@@ -30,6 +30,7 @@ export default function HelpPage() {
         <li><strong>Sidequests</strong> – optional tasks for extra points.</li>
         <li><strong>Players & Teams</strong> – browse all participants.</li>
         <li><strong>Scoreboard</strong> – see who&apos;s leading the hunt.</li>
+        <li><strong>Kudos</strong> – vote for players in fun categories.</li>
         <li>
           <strong>Rogues Gallery</strong> – view and react to uploaded photos
           from sidequest submissions.

--- a/client/src/pages/KudosPage.js
+++ b/client/src/pages/KudosPage.js
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { fetchKudos, fetchPlayersPublic, voteKudos } from '../services/api';
+
+export default function KudosPage() {
+  const [categories, setCategories] = useState([]);
+  const [players, setPlayers] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [catRes, playersRes] = await Promise.all([
+          fetchKudos(),
+          fetchPlayersPublic()
+        ]);
+        setCategories(catRes.data);
+        setPlayers(playersRes.data);
+      } catch (err) {
+        console.error('Failed to load kudos', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const handleVote = async (catId, recipient) => {
+    try {
+      await voteKudos(catId, recipient);
+      const { data } = await fetchKudos();
+      setCategories(data);
+    } catch (err) {
+      alert(err.response?.data?.message || 'Error voting');
+    }
+  };
+
+  if (loading) return <p>Loading…</p>;
+
+  return (
+    <div className="card spaced-card">
+      <h2>Kudos</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Your Vote</th>
+            <th>Current Leader</th>
+          </tr>
+        </thead>
+        <tbody>
+          {categories.map((c) => (
+            <tr key={c._id}>
+              <td>{c.title}</td>
+              <td data-label="Your Vote">
+                <select
+                  value={c.myVote || ''}
+                  onChange={(e) => handleVote(c._id, e.target.value)}
+                >
+                  <option value="">-- choose --</option>
+                  {players.map((p) => (
+                    <option key={p._id} value={p._id}>
+                      {p.firstName || p.name}
+                    </option>
+                  ))}
+                </select>
+              </td>
+              <td data-label="Current Leader">
+                {c.leader ? (
+                  <>
+                    {c.leader.photoUrl && (
+                      <img
+                        src={c.leader.photoUrl}
+                        alt="leader"
+                        style={{
+                          width: '40px',
+                          height: '40px',
+                          borderRadius: '50%',
+                          objectFit: 'cover',
+                          marginRight: '0.5rem'
+                        }}
+                      />
+                    )}
+                    {c.leader.firstName}
+                  </>
+                ) : (
+                  '—'
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -126,6 +126,18 @@ export const fetchAdminSummary = () =>
 export const fetchScoreboard = () => axios.get('/api/scoreboard');
 export const fetchAdminScoreboard = () => axios.get('/api/admin/scoreboard');
 
+// Kudos endpoints
+export const fetchKudos = () => axios.get('/api/kudos');
+export const voteKudos = (id, recipient) =>
+  axios.post(`/api/kudos/${id}/vote`, { recipient });
+export const fetchKudosAdmin = () => axios.get('/api/admin/kudos');
+export const createKudosCategory = (data) =>
+  axios.post('/api/admin/kudos', data);
+export const updateKudosCategory = (id, data) =>
+  axios.put(`/api/admin/kudos/${id}`, data);
+export const deleteKudosCategory = (id) =>
+  axios.delete(`/api/admin/kudos/${id}`);
+
 // Player progress tables
 export const fetchProgress = (type) => axios.get(`/api/progress/${type}`);
 

--- a/server/controllers/kudosController.js
+++ b/server/controllers/kudosController.js
@@ -1,0 +1,148 @@
+const KudosCategory = require('../models/KudosCategory');
+const KudosVote = require('../models/KudosVote');
+const User = require('../models/User');
+const { createNotification } = require('../utils/notifications');
+const mongoose = require('mongoose');
+
+// Helper to recalc and store the leader for a category
+async function updateLeader(categoryId) {
+  const votes = await KudosVote.aggregate([
+    { $match: { category: new mongoose.Types.ObjectId(categoryId) } },
+    { $group: { _id: '$recipient', count: { $sum: 1 } } },
+    { $sort: { count: -1 } },
+    { $limit: 1 }
+  ]);
+  if (!votes.length) {
+    await KudosCategory.findByIdAndUpdate(categoryId, {
+      leadingUser: null,
+      leadingCount: 0
+    });
+    return null;
+  }
+  const top = votes[0];
+  const cat = await KudosCategory.findById(categoryId);
+  const prevLeader = cat.leadingUser?.toString();
+  await KudosCategory.findByIdAndUpdate(categoryId, {
+    leadingUser: top._id,
+    leadingCount: top.count
+  });
+  if (prevLeader !== String(top._id)) {
+    // Notify the new leader
+    const user = await User.findById(top._id);
+    if (user) {
+      await createNotification({
+        user: user._id,
+        message: `You are now leading "${cat.title}" kudos!`
+      });
+    }
+  }
+  return top;
+}
+
+// Public: list categories with current leader info
+exports.listCategories = async (req, res) => {
+  try {
+    const cats = await KudosCategory.find()
+      .sort({ createdAt: 1 })
+      .populate('leadingUser', 'firstName photoUrl');
+    // Also include the current user's votes
+    let votes = [];
+    if (req.user) {
+      votes = await KudosVote.find({ voter: req.user._id });
+    }
+    const voteMap = new Map(votes.map(v => [v.category.toString(), v.recipient.toString()]));
+    const data = cats.map(c => ({
+      _id: c._id,
+      title: c.title,
+      leader: c.leadingUser ? {
+        _id: c.leadingUser._id,
+        firstName: c.leadingUser.firstName,
+        photoUrl: c.leadingUser.photoUrl
+      } : null,
+      myVote: voteMap.get(c._id.toString()) || null
+    }));
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching kudos categories' });
+  }
+};
+
+// Cast or update a vote for a kudos category
+exports.castVote = async (req, res) => {
+  const { id } = req.params;
+  const { recipient } = req.body;
+  if (!recipient) {
+    return res.status(400).json({ message: 'Recipient is required' });
+  }
+  try {
+    const category = await KudosCategory.findById(id);
+    if (!category) return res.status(404).json({ message: 'Category not found' });
+    const vote = await KudosVote.findOneAndUpdate(
+      { category: id, voter: req.user._id },
+      { recipient },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    // Notify the recipient of the vote
+    const actor = await User.findById(req.user._id);
+    const recUser = await User.findById(recipient);
+    if (recUser) {
+      await createNotification({
+        user: recUser._id,
+        actor,
+        message: `${actor.firstName} voted for you as "${category.title}"`
+      });
+    }
+    // Recalculate leader
+    await updateLeader(id);
+    res.json(vote);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error casting vote' });
+  }
+};
+
+// Admin: CRUD operations
+exports.createCategory = async (req, res) => {
+  try {
+    const cat = await KudosCategory.create({ title: req.body.title });
+    res.status(201).json(cat);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error creating category' });
+  }
+};
+
+exports.updateCategory = async (req, res) => {
+  try {
+    const cat = await KudosCategory.findByIdAndUpdate(req.params.id, { title: req.body.title }, { new: true });
+    if (!cat) return res.status(404).json({ message: 'Category not found' });
+    res.json(cat);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error updating category' });
+  }
+};
+
+exports.deleteCategory = async (req, res) => {
+  try {
+    await KudosVote.deleteMany({ category: req.params.id });
+    const cat = await KudosCategory.findByIdAndDelete(req.params.id);
+    if (!cat) return res.status(404).json({ message: 'Category not found' });
+    res.json({ message: 'Category deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error deleting category' });
+  }
+};
+
+exports.getAllCategories = async (req, res) => {
+  try {
+    const cats = await KudosCategory.find().sort({ createdAt: 1 });
+    res.json(cats);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Error fetching categories' });
+  }
+};
+

--- a/server/models/KudosCategory.js
+++ b/server/models/KudosCategory.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const kudosCategorySchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true },
+    leadingUser: { type: mongoose.Schema.Types.ObjectId, ref: 'User', default: null },
+    leadingCount: { type: Number, default: 0 }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('KudosCategory', kudosCategorySchema);

--- a/server/models/KudosVote.js
+++ b/server/models/KudosVote.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const kudosVoteSchema = new mongoose.Schema(
+  {
+    category: { type: mongoose.Schema.Types.ObjectId, ref: 'KudosCategory', required: true },
+    voter: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    recipient: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true }
+  },
+  { timestamps: true }
+);
+
+// Ensure a player can only vote once per category
+kudosVoteSchema.index({ category: 1, voter: 1 }, { unique: true });
+
+module.exports = mongoose.model('KudosVote', kudosVoteSchema);

--- a/server/routes/admin/kudos.js
+++ b/server/routes/admin/kudos.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const adminAuth = require('../../middleware/adminAuth');
+const {
+  createCategory,
+  updateCategory,
+  deleteCategory,
+  getAllCategories
+} = require('../../controllers/kudosController');
+
+router.use(adminAuth);
+
+router.get('/', getAllCategories);
+router.post('/', createCategory);
+router.put('/:id', updateCategory);
+router.delete('/:id', deleteCategory);
+
+module.exports = router;

--- a/server/routes/kudos.js
+++ b/server/routes/kudos.js
@@ -1,0 +1,29 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const { listCategories, castVote } = require('../controllers/kudosController');
+
+// List categories and current leaders. Authentication optional.
+router.get('/', authOptional, listCategories);
+
+// Players cast or update a vote in a category
+router.post('/:id/vote', auth, castVote);
+
+// Middleware allowing optional auth (for listing when logged out)
+async function authOptional(req, res, next) {
+  const header = req.headers.authorization;
+  if (header?.startsWith('Bearer ')) {
+    try {
+      const jwt = require('jsonwebtoken');
+      const User = require('../models/User');
+      const token = header.split(' ')[1];
+      const decoded = jwt.verify(token, process.env.JWT_SECRET);
+      req.user = await User.findById(decoded.id).select('-password');
+    } catch {
+      // ignore errors and continue without user
+    }
+  }
+  next();
+}
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -84,6 +84,8 @@ app.use('/api/settings', require('./routes/settings'));
 
 // Public scoreboard route
 app.use('/api/scoreboard', require('./routes/scoreboard'));
+// Kudos voting and categories
+app.use('/api/kudos', require('./routes/kudos'));
 
 // ——— NEW ADMIN AUTH ROUTE ———
 app.use('/api/admin/auth', require('./routes/adminAuth'));
@@ -98,6 +100,7 @@ app.use('/api/admin/players',  require('./routes/admin/players'));
 app.use('/api/admin/teams',  require('./routes/admin/teams'));
 app.use('/api/admin/scoreboard', require('./routes/admin/scoreboard'));
 app.use('/api/admin/settings', require('./routes/admin/settings'));
+app.use('/api/admin/kudos', require('./routes/admin/kudos'));
 // Broadcast system notifications to all players
 app.use('/api/admin/notifications', require('./routes/admin/notifications'));
 // Route allowing admins to download all uploaded media as a zip


### PR DESCRIPTION
## Summary
- add models and controllers for kudos categories and voting
- expose new `/api/kudos` and admin CRUD routes
- notify players when they receive votes and when they lead a category
- add player and admin pages for kudos and update sidebar
- document kudos feature in README and help page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866da61202083288d165071a3f5f2b5