### PR TITLE
Fix missing Link import in Dashboard

### DIFF
--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -9,6 +9,8 @@ import {
   fetchPlayersPublic,
   fetchSettings
 } from '../services/api';
+// React Router Link component lets us navigate client-side without reloading
+import { Link } from 'react-router-dom';
 import TeamMemberForm from '../components/TeamMemberForm';
 
 export default function Dashboard() {


### PR DESCRIPTION
## Summary
- import Link in Dashboard page so menu links don't break
- add clarifying comment for the new import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866f0e862e48328a353198ac640ea3d