### PR TITLE
Improve signup flow with tabs

### DIFF
--- a/client/src/pages/SignupPage.js
+++ b/client/src/pages/SignupPage.js
@@ -87,19 +87,20 @@ export default function SignupPage() {
       <label>Your Selfie:</label>
       <ProfilePic avatarUrl={selfieUrl} onFileSelect={handleSelfieSelect} />
 
-      <div style={{ display: 'flex', margin: '1rem 0' }}>
+      {/* Tab controls replace the old buttons. The active tab is styled via CSS */}
+      {/* Container uses shared tab styles from index.css for consistency */}
+      <div className="tab-container" style={{ margin: '1rem 0' }}>
         <button
           type="button"
-          className="btn-mr"
+          className={`tab ${tab === 'existing' ? 'active' : ''}`}
           onClick={() => setTab('existing')}
-          style={{ background: tab === 'existing' ? 'var(--secondary-color)' : 'var(--primary-color)' }}
         >
-          Choose Existing Team
+          Join Existing Team
         </button>
         <button
           type="button"
+          className={`tab ${tab === 'new' ? 'active' : ''}`}
           onClick={() => setTab('new')}
-          style={{ background: tab === 'new' ? 'var(--secondary-color)' : 'var(--primary-color)' }}
         >
           Create New Team
         </button>


### PR DESCRIPTION
## Summary
- replace team selection buttons on signup with tabbed UI
- document new tabbed layout in SignupPage

## Testing
- `npm test` in `server`
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866fa86e92c83288677a323c8a7ba78