### PR TITLE
Add QR codes to crib sheet

### DIFF
--- a/client/src/pages/AdminCribSheetPage.js
+++ b/client/src/pages/AdminCribSheetPage.js
@@ -2,35 +2,28 @@ import React, { useEffect, useState } from 'react';
 import {
   fetchClues,
   fetchQuestions,
-  fetchSideQuestsAdmin,
-  fetchPlayers,
-  fetchTeamsAdmin
+  fetchSideQuestsAdmin
 } from '../services/api';
+import ExpandableQr from '../components/ExpandableQr';
 
 // Printable overview for gamemasters showing all game data
 export default function AdminCribSheetPage() {
   const [clues, setClues] = useState([]);
   const [questions, setQuestions] = useState([]);
   const [quests, setQuests] = useState([]);
-  const [players, setPlayers] = useState([]);
-  const [teams, setTeams] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const load = async () => {
       try {
-        const [cRes, qRes, sqRes, pRes, tRes] = await Promise.all([
+        const [cRes, qRes, sqRes] = await Promise.all([
           fetchClues(),
           fetchQuestions(),
-          fetchSideQuestsAdmin(),
-          fetchPlayers(),
-          fetchTeamsAdmin()
+          fetchSideQuestsAdmin()
         ]);
         setClues(cRes.data);
         setQuestions(qRes.data);
         setQuests(sqRes.data);
-        setPlayers(pRes.data);
-        setTeams(tRes.data);
       } catch (err) {
         console.error('Error loading crib sheet data:', err);
       } finally {
@@ -51,6 +44,7 @@ export default function AdminCribSheetPage() {
       <table>
         <thead>
           <tr>
+            <th>QR</th>
             <th>Title</th>
             <th>Text</th>
             <th>Answer</th>
@@ -59,6 +53,12 @@ export default function AdminCribSheetPage() {
         <tbody>
           {clues.map((c) => (
             <tr key={c._id}>
+              <td>
+                {c.qrCodeData && (
+                  /* Large QR so printed copies can be scanned */
+                  <img src={c.qrCodeData} alt={`QR for ${c.title}`} width={120} />
+                )}
+              </td>
               <td>{c.title}</td>
               <td>{c.text}</td>
               <td>{c.correctAnswer}</td>
@@ -71,6 +71,7 @@ export default function AdminCribSheetPage() {
       <table>
         <thead>
           <tr>
+            <th>QR</th>
             <th>Title</th>
             <th>Question</th>
             <th>Answer</th>
@@ -79,6 +80,12 @@ export default function AdminCribSheetPage() {
         <tbody>
           {questions.map((q) => (
             <tr key={q._id}>
+              <td>
+                {q.qrCodeData && (
+                  /* Include QR for each question */
+                  <img src={q.qrCodeData} alt={`QR for ${q.title}`} width={120} />
+                )}
+              </td>
               <td>{q.title}</td>
               <td>{q.text}</td>
               <td>{q.correctAnswer}</td>
@@ -91,6 +98,7 @@ export default function AdminCribSheetPage() {
       <table>
         <thead>
           <tr>
+            <th>QR</th>
             <th>Title</th>
             <th>Text</th>
             <th>Time Limit</th>
@@ -99,6 +107,12 @@ export default function AdminCribSheetPage() {
         <tbody>
           {quests.map((q) => (
             <tr key={q._id}>
+              <td>
+                {q.qrCodeData && (
+                  /* Display quest QR for quick scanning */
+                  <img src={q.qrCodeData} alt={`QR for ${q.title}`} width={120} />
+                )}
+              </td>
               <td>{q.title}</td>
               <td>{q.text}</td>
               <td>{q.timeLimitSeconds || '-'}</td>
@@ -107,41 +121,6 @@ export default function AdminCribSheetPage() {
         </tbody>
       </table>
 
-      <h3>Teams</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Leader</th>
-          </tr>
-        </thead>
-        <tbody>
-          {teams.map((t) => (
-            <tr key={t._id}>
-              <td>{t.name}</td>
-              <td>{t.leader ? t.leader.name : '-'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      <h3>Players</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Team</th>
-          </tr>
-        </thead>
-        <tbody>
-          {players.map((p) => (
-            <tr key={p._id}>
-              <td>{p.name}</td>
-              <td>{p.team ? p.team.name : '-'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show QR codes in crib sheet for clues, questions and side quests
- remove teams and players sections from admin crib sheet

## Testing
- `npm test` in `server`
- `npm test` in `client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866fadb651883288168c96a28db79ae