### PR TITLE
Fix logout menu item alignment

### DIFF
--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -265,6 +265,23 @@ form label {
 }
 
 /*
+ * Style buttons like plain text links. This removes the generic button
+ * padding and margin so items such as the Log Out action align with link
+ * entries in dropdown menus.
+ */
+.btn-link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: var(--text-color);
+  font-size: 1rem;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+/*
  * Tabs used on the welcome screen. Each tab button has no shadow so it
  * blends with the container. The active tab is highlighted and connects
  * visually with the card below.


### PR DESCRIPTION
## Summary
- style button used for logout like a text link so it aligns with other dropdown items

## Testing
- `npm install` within `server`
- `npm test` within `server`

------
https://chatgpt.com/codex/tasks/task_e_6866fb2180ac83288022f1051b485c9c