### PR TITLE
Fix signup profile picture state

### DIFF
--- a/client/src/pages/SignupPage.js
+++ b/client/src/pages/SignupPage.js
@@ -9,13 +9,17 @@ import ProfilePic from '../components/ProfilePic';
 export default function SignupPage() {
   const { state } = useLocation();
   const navigate = useNavigate();
-  // Expect first and last names plus optional selfie preview
-  const { firstName, lastName, next, selfiePreview } = state || {};
+  // Expect first/last names plus optional selfie preview and file
+  // The file comes from the previous signup step so users don't
+  // need to reselect their photo here
+  const { firstName, lastName, next, selfiePreview, selfieFile: passedSelfie } =
+    state || {};
 
   const [teams, setTeams] = useState([]);
   const [leaderNames, setLeaderNames] = useState({});
   const [showJoinInput, setShowJoinInput] = useState({});
-  const [selfieFile, setSelfieFile] = useState(null);
+  // Initialize the selfie file and preview from the passed state if available
+  const [selfieFile, setSelfieFile] = useState(passedSelfie || null);
   const [selfieUrl, setSelfieUrl] = useState(selfiePreview || '');
   const [teamName, setTeamName] = useState('');
   const [teamPhotoFile, setTeamPhotoFile] = useState(null);

--- a/client/src/pages/WelcomePage.js
+++ b/client/src/pages/WelcomePage.js
@@ -60,7 +60,11 @@ export default function WelcomePage() {
       alert('Please take or upload a photo first');
       return;
     }
-    navigate('/signup', { state: { firstName, lastName, next, selfiePreview } });
+    // Pass both the preview URL and the actual File object so the next step
+    // can submit the selfie without requiring the user to reselect it
+    navigate('/signup', {
+      state: { firstName, lastName, next, selfiePreview, selfieFile }
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- keep selfie file when moving from signup step 1 to step 2
- initialize SignupPage state with the passed selfie file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866fc2866808328aaf6c8313055748b