### PR TITLE
Improve sidequest listing

### DIFF
--- a/client/src/pages/ItemTablePage.js
+++ b/client/src/pages/ItemTablePage.js
@@ -6,6 +6,8 @@ import { fetchProgress } from '../services/api';
 export default function ItemTablePage({ type, titlePrefix }) {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
+  // Track which items to display based on completion state
+  const [filter, setFilter] = useState('all'); // all | complete | incomplete
 
   useEffect(() => {
     const load = async () => {
@@ -24,6 +26,12 @@ export default function ItemTablePage({ type, titlePrefix }) {
   if (loading) return <p>Loading…</p>;
 
   const remaining = items.filter((i) => !i.scanned).length;
+  // Apply completion filter to the list
+  const filteredItems = items.filter((it) => {
+    if (filter === 'complete') return it.status === 'DONE!';
+    if (filter === 'incomplete') return it.status !== 'DONE!';
+    return true;
+  });
 
   // List of all game items in a card
   return (
@@ -33,6 +41,23 @@ export default function ItemTablePage({ type, titlePrefix }) {
         Your team has found the following {titlePrefix.toLowerCase()} - {remaining}{' '}
         {titlePrefix.toLowerCase()} remaining!
       </p>
+      {/* Completion filter for side quests */}
+      {type === 'sidequest' && (
+        <div style={{ marginBottom: '0.5rem' }}>
+          <label>
+            Show:
+            <select
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              <option value="all">All</option>
+              <option value="incomplete">Incomplete</option>
+              <option value="complete">Completed</option>
+            </select>
+          </label>
+        </div>
+      )}
       <table>
         <thead>
           <tr>
@@ -41,11 +66,14 @@ export default function ItemTablePage({ type, titlePrefix }) {
           </tr>
         </thead>
         <tbody>
-          {items.map((it) => (
+          {filteredItems.map((it) => (
             <tr key={it._id}>
               <td data-label="Title">
-                {it.scanned ? (
-                  <Link to={`/${type === 'sidequest' ? 'sidequest' : type}/${it._id}`}>{it.title}</Link>
+                {type === 'sidequest' ? (
+                  // Side quests are always clickable regardless of scan state
+                  <Link to={`/sidequest/${it._id}`}>{it.title}</Link>
+                ) : it.scanned ? (
+                  <Link to={`/${type}/${it._id}`}>{it.title}</Link>
                 ) : (
                   it.title
                 )}

--- a/server/controllers/progressController.js
+++ b/server/controllers/progressController.js
@@ -133,10 +133,18 @@ exports.getItemScanStats = async (req, res) => {
       : SideQuest;
 
   try {
-    // Include the team name when listing side quests or players
-    let query = Model.find().sort({ createdAt: 1 });
-    if (type === 'sidequest' || type === 'player') {
-      query = query.populate('team', 'name');
+    // Build the base query for the requested item type
+    let query = Model.find();
+    if (type === 'sidequest') {
+      // Side quests should be ordered newest first
+      query = query.sort({ createdAt: -1 }).populate('team', 'name');
+    } else {
+      // Other items keep the original ascending order
+      query = query.sort({ createdAt: 1 });
+      if (type === 'player') {
+        // Players also show their team name
+        query = query.populate('team', 'name');
+      }
     }
     const [items, team] = await Promise.all([
       query,

--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -28,7 +28,9 @@ async function ensureQrCode(sq) {
 
 exports.getAllSideQuests = async (req, res) => {
   try {
-    const sideQuests = await SideQuest.find({ active: true }).sort({ createdAt: 1 });
+    const sideQuests = await SideQuest.find({ active: true })
+      // Sort newest to oldest so recent quests appear first
+      .sort({ createdAt: -1 });
     await Promise.all(sideQuests.map((sq) => ensureQrCode(sq)));
     res.json(sideQuests);
   } catch (err) {


### PR DESCRIPTION
## Summary
- sort side quests newest first in the API
- return side quests newest first in progress stats
- always link to side quest details
- add completion filter for side quest tables

## Testing
- `npm test --silent --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6867a26f5c748328b6811b6e520c75bd