### PR TITLE
Redirect on new side quest save

### DIFF
--- a/client/src/pages/CreateSideQuestPage.js
+++ b/client/src/pages/CreateSideQuestPage.js
@@ -45,7 +45,9 @@ export default function CreateSideQuestPage() {
       formData.append('title', title);
       formData.append('questType', questType);
       const res = await createSideQuest(formData);
-      navigate(`/sidequests/${res.data._id}/edit`);
+      // Pass ?new=1 so the edit page knows this is a freshly
+      // created quest and can redirect to the detail view on save
+      navigate(`/sidequests/${res.data._id}/edit?new=1`);
     } catch (err) {
       console.error(err);
       alert(err.response?.data?.message || 'Error creating side quest');

--- a/client/src/pages/SideQuestEditPage.js
+++ b/client/src/pages/SideQuestEditPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import ExpandableQr from '../components/ExpandableQr';
 import ImageSelector from '../components/ImageSelector';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import {
   fetchSideQuest,
   updateSideQuest,
@@ -13,6 +13,9 @@ import {
 export default function SideQuestEditPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  // Detect if the edit page was opened immediately after creating a new quest
+  const isNew = new URLSearchParams(location.search).get('new') === '1';
   const [quest, setQuest] = useState(null);
   const [loading, setLoading] = useState(true);
   // Lists of potential targets for bonus quests
@@ -86,8 +89,14 @@ export default function SideQuestEditPage() {
         payload = formData;
       }
       await updateSideQuest(id, payload);
-      alert('Saved');
-      loadQuest();
+      if (isNew) {
+        // After saving a newly created quest, send the player to the
+        // quest's detail page to start interacting with it
+        navigate(`/sidequest/${id}`);
+      } else {
+        alert('Saved');
+        loadQuest();
+      }
     } catch (err) {
       console.error(err);
       alert(err.response?.data?.message || 'Error saving side quest');


### PR DESCRIPTION
## Summary
- when creating a side quest pass `?new=1` to edit page
- detect the `new` flag on edit page and redirect to the detail view after saving

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867a4a61e948328b54314b34187680b