### PR TITLE
Improve admin table mobile layout

### DIFF
--- a/client/src/pages/AdminCluesPage.js
+++ b/client/src/pages/AdminCluesPage.js
@@ -99,7 +99,8 @@ export default function AdminCluesPage() {
       <p>
         <Link to="/admin/cribsheet">Print Crib Sheet</Link>
       </p>
-      <table>
+      {/* responsive table for clues */}
+      <table className="admin-table">
         <thead>
           <tr>
             <th>Title</th>

--- a/client/src/pages/AdminQuestionsPage.js
+++ b/client/src/pages/AdminQuestionsPage.js
@@ -97,7 +97,8 @@ export default function AdminQuestionsPage() {
       <p>
         <Link to="/admin/cribsheet">Print Crib Sheet</Link>
       </p>
-      <table>
+      {/* responsive table for managing questions */}
+      <table className="admin-table">
         <thead>
           <tr>
             <th>Title</th>

--- a/client/src/pages/AdminSideQuestsPage.js
+++ b/client/src/pages/AdminSideQuestsPage.js
@@ -101,7 +101,8 @@ export default function AdminSideQuestsPage() {
       <p>
         <Link to="/admin/cribsheet">Print Crib Sheet</Link>
       </p>
-      <table>
+      {/* responsive table for side quests */}
+      <table className="admin-table">
         <thead>
           <tr>
             <th>Title</th>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -422,6 +422,50 @@ tbody tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
+/*
+ * Admin tables have a simpler responsive style that hides column headers and
+ * stacks each row vertically on phones. Other tables still use the data-label
+ * approach above.
+ */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid #ddd;
+  text-align: left;
+}
+
+.admin-table tbody tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+
+@media (max-width: 600px) {
+  .admin-table,
+  .admin-table thead,
+  .admin-table tbody,
+  .admin-table th,
+  .admin-table td,
+  .admin-table tr {
+    display: block;
+  }
+  .admin-table thead {
+    display: none;
+  }
+  .admin-table tr {
+    margin-bottom: 1rem;
+    border-bottom: 2px solid #ddd;
+    padding: 0.5rem 0;
+  }
+  .admin-table td {
+    padding: 0.25rem 0;
+    border: none;
+  }
+}
+
 @media (max-width: 600px) {
   /* Stack table rows vertically on very narrow screens */
   table,


### PR DESCRIPTION
## Summary
- add `.admin-table` CSS class for mobile-friendly admin tables
- use the new class in questions, clues, and side quests admin pages

## Testing
- `npm install` within `server`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867b454a6c883288bcf414868c494eb