### PR TITLE
Fix admin tables on small screens

### DIFF
--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -463,6 +463,12 @@ tbody tr:nth-child(even) {
   .admin-table td {
     padding: 0.25rem 0;
     border: none;
+    position: static; /* override global rule used for other tables */
+    padding-left: 0;  /* don't reserve space for pseudo-labels */
+  }
+  /* Hide the data-label pseudo elements for admin tables */
+  .admin-table td::before {
+    content: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- hide pseudo-labels on `.admin-table` for mobile layouts

## Testing
- `npm test --silent` in `client`
- `npm test --silent` in `server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b8da7be48328b17a53e74a59b8c9