### PR TITLE
Add return links on item detail pages

### DIFF
--- a/client/src/pages/QuestionPage.js
+++ b/client/src/pages/QuestionPage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { fetchClue, fetchProgressItem } from '../services/api';
 
 // Question view for the single active game
@@ -37,6 +37,10 @@ export default function QuestionPage() {
 
   return (
     <div>
+      {/* Link back to the full list of clues */}
+      <Link to="/progress/clues" className="btn-link">
+        &larr; Return to list
+      </Link>
       <h2>{clue.title}</h2>
       <div className="card">
         <p>{clue.text}</p>

--- a/client/src/pages/QuestionPlayPage.js
+++ b/client/src/pages/QuestionPlayPage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   fetchQuestion,
   submitQuestionAnswer,
@@ -81,6 +81,10 @@ export default function QuestionPlayPage() {
 
   return (
     <div>
+      {/* Link back to the list of questions */}
+      <Link to="/progress/questions" className="btn-link">
+        &larr; Return to list
+      </Link>
       <h2>{question.title}</h2>
       <div className="card">
         <p>{question.text}</p>

--- a/client/src/pages/SideQuestDetailPage.js
+++ b/client/src/pages/SideQuestDetailPage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import {
   fetchSideQuest,
   submitSideQuest,
@@ -86,6 +86,10 @@ export default function SideQuestDetailPage() {
 
   return (
     <div>
+      {/* Link back to all side quests */}
+      <Link to="/sidequests" className="btn-link">
+        &larr; Return to list
+      </Link>
       <h2>{quest.title}</h2>
       <div className="card">
         <p>{quest.text}</p>


### PR DESCRIPTION
## Summary
- add `Link` imports in detail pages
- add "Return to list" buttons in QuestionPage, SideQuestDetailPage and QuestionPlayPage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867bc018f94832897750b1a59b25584