### PR TITLE
Implement admin-only sidequest types

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -35,7 +35,7 @@ import AdminPlayersPage from './pages/AdminPlayersPage';
 import AdminTeamsPage from './pages/AdminTeamsPage';
 import AdminGalleryPage from './pages/AdminGalleryPage';
 import AdminSettingsPage from './pages/AdminSettingsPage';
-import AdminInstructionsPage from './pages/AdminInstructionsPage';
+import AdminSideQuestConfigPage from './pages/AdminSideQuestConfigPage';
 import AdminKudosPage from './pages/AdminKudosPage';
 
 import AdminLoginPage from './pages/AdminLoginPage';
@@ -359,10 +359,10 @@ export default function App() {
                 }
               />
               <Route
-                path="/admin/instructions"
+                path="/admin/sidequest-config"
                 element={
                   <AdminRoute>
-                    <AdminInstructionsPage />
+                    <AdminSideQuestConfigPage />
                   </AdminRoute>
                 }
               />

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -58,7 +58,7 @@ export default function Sidebar() {
           {renderLink('/admin/kudos', 'Kudos')}
           {renderLink('/admin/gallery', 'Gallery')}
           {renderLink('/admin/settings', 'Settings')}
-          {renderLink('/admin/instructions', 'Instructions')}
+          {renderLink('/admin/sidequest-config', 'SideQuest Config')}
         </>
       )}
     </aside>

--- a/client/src/pages/NewSideQuestPage.js
+++ b/client/src/pages/NewSideQuestPage.js
@@ -6,7 +6,8 @@ import {
   updateSideQuest,
   deleteSideQuest,
   fetchProgress,
-  fetchMe
+  fetchMe,
+  fetchSettings
 } from '../services/api';
 
 // Player managed side quests with CRUD functionality
@@ -16,6 +17,7 @@ export default function NewSideQuestPage() {
   const [quests, setQuests] = useState([]);
   const [scannedItems, setScannedItems] = useState([]); // items scanned by the team
   const [teamName, setTeamName] = useState('');
+  const [hideTypes, setHideTypes] = useState({});
   const [filter, setFilter] = useState('');
   const [newQuest, setNewQuest] = useState({
     title: '',
@@ -35,12 +37,22 @@ export default function NewSideQuestPage() {
       try {
         const { data } = await fetchMe();
         setTeamName(data.team?.name || '');
+        const settingsRes = await fetchSettings();
+        setHideTypes(settingsRes.data.sideQuestAdminOnly || {});
       } catch (err) {
         console.error(err);
       }
     };
     loadMe();
   }, []);
+
+  // Ensure the selected quest type is permitted once settings load
+  useEffect(() => {
+    if (hideTypes[newQuest.questType]) {
+      const first = questTypeOptions.find((o) => !hideTypes[o.value]);
+      if (first) setNewQuest((q) => ({ ...q, questType: first.value }));
+    }
+  }, [hideTypes]);
 
   useEffect(() => {
     if (newQuest.questType === 'bonus' && teamName) {
@@ -135,15 +147,15 @@ export default function NewSideQuestPage() {
     }
   };
 
-  const questTypeOptions = [
+  const allQuestTypeOptions = [
     { value: 'bonus', label: 'Bonus hunt!' },
     { value: 'meetup', label: 'Come and meet us!' },
     { value: 'photo', label: 'Take a photo!' },
     { value: 'race', label: 'Race!' },
-    // additional suggestions
     { value: 'passcode', label: 'Secret Passcode!' },
     { value: 'trivia', label: 'Trivia Challenge!' }
   ];
+  const questTypeOptions = allQuestTypeOptions.filter((o) => !hideTypes[o.value]);
 
   return (
     <div className="card spaced-card">

--- a/server/controllers/settingsController.js
+++ b/server/controllers/settingsController.js
@@ -47,6 +47,16 @@ exports.updateSettings = async (req, res) => {
       }
     }
 
+    // sideQuestAdminOnly may also arrive as JSON from the client
+    if (typeof updates.sideQuestAdminOnly === 'string') {
+      try {
+        updates.sideQuestAdminOnly = JSON.parse(updates.sideQuestAdminOnly);
+      } catch (e) {
+        console.error('Invalid sideQuestAdminOnly JSON');
+        delete updates.sideQuestAdminOnly;
+      }
+    }
+
     // Attach uploaded files if present
     if (req.files && req.files.logo && req.files.logo[0]) {
       updates.logoUrl = '/uploads/' + req.files.logo[0].filename;

--- a/server/models/Settings.js
+++ b/server/models/Settings.js
@@ -55,6 +55,16 @@ const settingsSchema = new mongoose.Schema({
       default:
         'Answer the trivia question correctly then upload your photo evidence.'
     }
+  },
+  // Flags to hide specific quest types from player creation/edit screens.
+  // When true, the type can only be created by admins via the dashboard.
+  sideQuestAdminOnly: {
+    bonus: { type: Boolean, default: false },
+    meetup: { type: Boolean, default: false },
+    photo: { type: Boolean, default: false },
+    race: { type: Boolean, default: false },
+    passcode: { type: Boolean, default: false },
+    trivia: { type: Boolean, default: false }
   }
 });
 


### PR DESCRIPTION
## Summary
- rename admin instructions page to AdminSideQuestConfigPage
- add sideQuestAdminOnly setting and parse in controller
- hide quest type options on player pages based on admin-only flags
- link new admin SideQuest Config page in sidebar and routes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867bbed20808328a6c89d59ce1c95b0