### PR TITLE
Fix admin side quest delete error

### DIFF
--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -132,7 +132,9 @@ exports.deleteSideQuest = async (req, res) => {
     ) {
       return res.status(403).json({ message: 'Not authorized' });
     }
-    await sq.remove();
+    // Mongoose v7 removed the `remove()` helper on documents.
+    // Use `deleteOne()` instead to properly delete the record.
+    await sq.deleteOne();
     res.json({ message: 'Side quest deleted' });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- fix side quest deletion when using admin CRUD page

## Testing
- `npm test --silent` in `server` *(fails: jest not found)*
- `npm test --silent` in `client` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6867be9d1e988328a02263f3dd4fc412