### PR TITLE
Fix SideQuest Config textarea focus loss

### DIFF
--- a/client/src/pages/AdminSideQuestConfigPage.js
+++ b/client/src/pages/AdminSideQuestConfigPage.js
@@ -1,6 +1,37 @@
 import React, { useEffect, useState } from 'react';
 import { fetchSettingsAdmin, updateSettingsAdmin } from '../services/api';
 
+/**
+ * Render a labeled textarea and admin-only toggle for a single quest type.
+ *
+ * This component is defined outside of the main page component so React
+ * preserves its identity between re-renders. When it was defined inline, each
+ * keystroke recreated the component, causing the textarea to lose focus. By
+ * moving it to module scope we ensure focus remains stable while typing.
+ */
+function QuestField({ type, label, value, onChange, adminOnly, onAdminToggle }) {
+  return (
+    <label style={{ display: 'block', marginBottom: '1rem' }}>
+      {label}:
+      <textarea
+        value={value || ''}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ width: '100%', height: '4rem', marginTop: '0.25rem' }}
+      />
+      <div style={{ marginTop: '0.25rem' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={adminOnly || false}
+            onChange={(e) => onAdminToggle(e.target.checked)}
+          />
+          Admin only
+        </label>
+      </div>
+    </label>
+  );
+}
+
 // Admin page for editing the default instructions shown for each
 // side quest type. The values are stored on the Settings document
 // under `sideQuestInstructions`.
@@ -64,30 +95,6 @@ export default function AdminSideQuestConfigPage() {
 
   if (loading) return <p>Loading…</p>;
 
-  // Helper component to render a labelled textarea for one quest type. Updates
-  // the corresponding field in state when edited.
-  const Field = ({ type, label }) => (
-    <label style={{ display: 'block', marginBottom: '1rem' }}>
-      {label}:
-      <textarea
-        value={instr[type] || ''}
-        onChange={(e) => setInstr({ ...instr, [type]: e.target.value })}
-        style={{ width: '100%', height: '4rem', marginTop: '0.25rem' }}
-      />
-      <div style={{ marginTop: '0.25rem' }}>
-        <label>
-          <input
-            type="checkbox"
-            checked={adminOnly[type] || false}
-            onChange={(e) =>
-              setAdminOnly({ ...adminOnly, [type]: e.target.checked })
-            }
-          />
-          Admin only
-        </label>
-      </div>
-    </label>
-  );
 
   return (
     <div className="card spaced-card" style={{ maxWidth: '600px' }}>
@@ -99,12 +106,58 @@ export default function AdminSideQuestConfigPage() {
           handleSave();
         }}
       >
-        <Field type="bonus" label="Bonus" />
-        <Field type="meetup" label="Meetup" />
-        <Field type="photo" label="Photo" />
-        <Field type="race" label="Race" />
-        <Field type="passcode" label="Passcode" />
-        <Field type="trivia" label="Trivia" />
+        {/*
+          Use the standalone QuestField component for each quest type. The
+          onChange handlers update the corresponding entry in state.
+        */}
+        <QuestField
+          type="bonus"
+          label="Bonus"
+          value={instr.bonus}
+          onChange={(val) => setInstr({ ...instr, bonus: val })}
+          adminOnly={adminOnly.bonus}
+          onAdminToggle={(val) => setAdminOnly({ ...adminOnly, bonus: val })}
+        />
+        <QuestField
+          type="meetup"
+          label="Meetup"
+          value={instr.meetup}
+          onChange={(val) => setInstr({ ...instr, meetup: val })}
+          adminOnly={adminOnly.meetup}
+          onAdminToggle={(val) => setAdminOnly({ ...adminOnly, meetup: val })}
+        />
+        <QuestField
+          type="photo"
+          label="Photo"
+          value={instr.photo}
+          onChange={(val) => setInstr({ ...instr, photo: val })}
+          adminOnly={adminOnly.photo}
+          onAdminToggle={(val) => setAdminOnly({ ...adminOnly, photo: val })}
+        />
+        <QuestField
+          type="race"
+          label="Race"
+          value={instr.race}
+          onChange={(val) => setInstr({ ...instr, race: val })}
+          adminOnly={adminOnly.race}
+          onAdminToggle={(val) => setAdminOnly({ ...adminOnly, race: val })}
+        />
+        <QuestField
+          type="passcode"
+          label="Passcode"
+          value={instr.passcode}
+          onChange={(val) => setInstr({ ...instr, passcode: val })}
+          adminOnly={adminOnly.passcode}
+          onAdminToggle={(val) => setAdminOnly({ ...adminOnly, passcode: val })}
+        />
+        <QuestField
+          type="trivia"
+          label="Trivia"
+          value={instr.trivia}
+          onChange={(val) => setInstr({ ...instr, trivia: val })}
+          adminOnly={adminOnly.trivia}
+          onAdminToggle={(val) => setAdminOnly({ ...adminOnly, trivia: val })}
+        />
         <button type="submit">Save</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- keep SideQuest config textarea focused while typing by moving field component outside render
- update field usages with explicit handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d3f5c42483289c64599cbd21220a