### PR TITLE
Add admin login link to sidebar

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -61,6 +61,8 @@ export default function Sidebar() {
           {renderLink('/admin/sidequest-config', 'SideQuest Config')}
         </>
       )}
+      {/* Provide a link for admins to sign in */}
+      {renderLink('/admin/login', 'Admin Login')}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- show an **Admin Login** link at the bottom of the sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867e56f80bc8328808787a99f85d749