### PR TITLE
Improve printable crib sheet

### DIFF
--- a/client/src/pages/AdminCribSheetPage.js
+++ b/client/src/pages/AdminCribSheetPage.js
@@ -55,8 +55,16 @@ export default function AdminCribSheetPage() {
             <tr key={c._id}>
               <td>
                 {c.qrCodeData && (
-                  /* Large QR so printed copies can be scanned */
-                  <img src={c.qrCodeData} alt={`QR for ${c.title}`} width={120} />
+                  /*
+                   * Display the QR with a caption underneath so a single
+                   * table cell can be printed and cut out as a label.
+                   */
+                  <div className="qr-wrapper">
+                    {/* Bigger QR to ensure easy scanning when printed */}
+                    <img src={c.qrCodeData} alt={`QR for ${c.title}`} width={180} />
+                    {/* Duplicate the title under the QR for standalone printouts */}
+                    <div className="qr-title">{c.title}</div>
+                  </div>
                 )}
               </td>
               <td>{c.title}</td>
@@ -82,8 +90,14 @@ export default function AdminCribSheetPage() {
             <tr key={q._id}>
               <td>
                 {q.qrCodeData && (
-                  /* Include QR for each question */
-                  <img src={q.qrCodeData} alt={`QR for ${q.title}`} width={120} />
+                  /*
+                   * Questions also need printable QR labels. The wrapper adds
+                   * the title beneath the code so each cell can be trimmed out.
+                   */
+                  <div className="qr-wrapper">
+                    <img src={q.qrCodeData} alt={`QR for ${q.title}`} width={180} />
+                    <div className="qr-title">{q.title}</div>
+                  </div>
                 )}
               </td>
               <td>{q.title}</td>
@@ -109,8 +123,15 @@ export default function AdminCribSheetPage() {
             <tr key={q._id}>
               <td>
                 {q.qrCodeData && (
-                  /* Display quest QR for quick scanning */
-                  <img src={q.qrCodeData} alt={`QR for ${q.title}`} width={120} />
+                  /*
+                   * Side quests also print their QR code with a caption so
+                   * individual squares can be cut out for hiding around the
+                   * venue.
+                   */
+                  <div className="qr-wrapper">
+                    <img src={q.qrCodeData} alt={`QR for ${q.title}`} width={180} />
+                    <div className="qr-title">{q.title}</div>
+                  </div>
                 )}
               </td>
               <td>{q.title}</td>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -467,9 +467,24 @@ tbody tr:nth-child(even) {
     padding-left: 0;  /* don't reserve space for pseudo-labels */
   }
   /* Hide the data-label pseudo elements for admin tables */
-  .admin-table td::before {
-    content: none;
-  }
+.admin-table td::before {
+  content: none;
+}
+}
+
+/*
+ * Small wrapper used on the printable crib sheet so QR codes are
+ * centered with their caption directly underneath. This makes it easy
+ * to cut out the QR plus title as a single piece of paper.
+ */
+.qr-wrapper {
+  text-align: center;
+}
+
+/* Title displayed below each QR code in the crib sheet */
+.qr-title {
+  margin-top: 0.25rem;
+  font-size: 0.85rem;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- enlarge QR code images on the admin crib sheet
- include titles directly under each QR so cut-outs are labeled
- add `.qr-wrapper` and `.qr-title` styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867f9b65e4883288c8e4c471a3cddc7