### PR TITLE
Fix print to show full crib sheet

### DIFF
--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -722,4 +722,21 @@ tbody tr:nth-child(even) {
     margin: 0;
     box-shadow: none;
   }
+  /* Allow content to expand so the full crib sheet prints */
+  html,
+  body,
+  #root {
+    height: auto;
+  }
+  .content {
+    overflow: visible;
+  }
+  /* Keep table rows intact across printed pages */
+  table {
+    page-break-inside: auto;
+  }
+  tr {
+    page-break-inside: avoid;
+    page-break-after: auto;
+  }
 }


### PR DESCRIPTION
## Summary
- allow entire page to print when using the crib sheet
- avoid breaking table rows across printed pages

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6867fd83a6408328953eee6f4c3d7ebc