### PR TITLE
Ensure side quests always visible

### DIFF
--- a/server/controllers/sideQuestController.js
+++ b/server/controllers/sideQuestController.js
@@ -28,9 +28,13 @@ async function ensureQrCode(sq) {
 
 exports.getAllSideQuests = async (req, res) => {
   try {
-    const sideQuests = await SideQuest.find({ active: true })
+    // Fetch every quest in the collection. Using an empty query ensures
+    // newly created quests immediately appear for all players regardless of
+    // any "active" flag that may have been set.
+    const sideQuests = await SideQuest.find()
       // Sort newest to oldest so recent quests appear first
       .sort({ createdAt: -1 });
+    // Ensure each quest has a QR code generated using the current base URL.
     await Promise.all(sideQuests.map((sq) => ensureQrCode(sq)));
     res.json(sideQuests);
   } catch (err) {

--- a/server/routes/sidequests.js
+++ b/server/routes/sidequests.js
@@ -13,7 +13,7 @@ const {
   updateMySideQuestSubmission
 } = require('../controllers/sideQuestController');
 
-// Authenticated player endpoint for active quests
+// Authenticated player endpoint for all quests
 router.get('/', auth, getAllSideQuests);
 // Public listing of quests (no auth required)
 router.get('/public', getAllSideQuests);


### PR DESCRIPTION
## Summary
- show every side quest regardless of `active` flag
- update route comments accordingly

## Testing
- `npm install` *(server)*
- `npm test` *(server)*

------
https://chatgpt.com/codex/tasks/task_e_686806f958d483289c00e82895f955fe