### PR TITLE
Improve onboarding feedback

### DIFF
--- a/client/src/pages/SignupPage.js
+++ b/client/src/pages/SignupPage.js
@@ -58,7 +58,11 @@ export default function SignupPage() {
       localStorage.setItem('token', data.token);
       navigate(next || '/roguery');
     } catch (err) {
-      alert(err.response?.data?.message || 'Unable to join team');
+      const msg = err.response?.data?.message;
+      const hint = msg
+        ? `Unable to join team because ${msg}. Try again.`
+        : 'Unable to join team due to a network error. Please try again.';
+      alert(hint);
     }
   };
 
@@ -80,7 +84,15 @@ export default function SignupPage() {
       localStorage.setItem('token', data.token);
       navigate(next || '/roguery');
     } catch (err) {
-      alert(err.response?.data?.message || 'Unable to create team');
+      const msg = err.response?.data?.message;
+      let advice = 'Please try again.';
+      if (msg === 'Team name already taken') advice = 'Choose a different team name.';
+      if (msg === 'Team photo is required') advice = 'Select a team photo.';
+      if (msg === 'Profile picture is required') advice = 'Upload a selfie.';
+      const hint = msg
+        ? `Unable to create team because ${msg}. ${advice}`
+        : 'Unable to create team due to a network error. Please try again.';
+      alert(hint);
     }
   };
 

--- a/server/controllers/onboardController.js
+++ b/server/controllers/onboardController.js
@@ -177,6 +177,13 @@ exports.onboard = async (req, res) => {
     });
   } catch (err) {
     console.error('Onboard error:', err);
+    // Handle common validation failures to provide clearer feedback
+    if (err.code === 11000) {
+      return res.status(400).json({ message: 'Team name already taken' });
+    }
+    if (err.message && err.message.includes('secret')) {
+      return res.status(500).json({ message: 'Server configuration error' });
+    }
     return res.status(500).json({ message: 'Server error during onboarding' });
   }
 };


### PR DESCRIPTION
## Summary
- add more specific onboarding error handling in the backend
- show detailed guidance when team creation or joining fails

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68682bf848cc83288c3e3da9b41f8c4f