### PR TITLE
Improve login tab clarity

### DIFF
--- a/client/src/pages/SignupPage.js
+++ b/client/src/pages/SignupPage.js
@@ -103,8 +103,12 @@ export default function SignupPage() {
       <label>Your Selfie:</label>
       <ProfilePic avatarUrl={selfieUrl} onFileSelect={handleSelfieSelect} />
 
-      {/* Tab controls replace the old buttons. The active tab is styled via CSS */}
-      {/* Container uses shared tab styles from index.css for consistency */}
+      {/*
+        Tab controls replace the old buttons. Styling is shared with the
+        welcome screen so whichever option is active uses the primary
+        colour, making it obvious whether players are joining an
+        existing team or creating a new one.
+      */}
       <div className="tab-container" style={{ margin: '1rem 0' }}>
         <button
           type="button"

--- a/client/src/pages/WelcomePage.js
+++ b/client/src/pages/WelcomePage.js
@@ -70,7 +70,11 @@ export default function WelcomePage() {
   return (
     <div className="card" style={{ maxWidth: 400, margin: '2rem auto' }}>
       <h2>Welcome</h2>
-      {/* Tab controls above the form; active tab is styled via CSS */}
+      {/*
+        Tab controls toggle between logging in and signing up.
+        The active tab is now highlighted via CSS so the current
+        mode is visually obvious to the player.
+      */}
       <div className="tab-container">
         <button
           type="button"

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -282,9 +282,10 @@ form label {
 }
 
 /*
- * Tabs used on the welcome screen. Each tab button has no shadow so it
- * blends with the container. The active tab is highlighted and connects
- * visually with the card below.
+ * Shared tab styles for login/signup and team selection screens.
+ * Each tab has no shadow so it blends with the surrounding card. The
+ * active tab now uses the primary colour so the selected mode stands
+ * out clearly for users.
  */
 .tab-container {
   display: flex;
@@ -296,17 +297,20 @@ form label {
   flex: 1;
   margin: 0;
   padding: 0.5rem 1rem;
-  background: var(--primary-color);
+  /* Inactive tabs match the card background */
+  background: var(--background-color);
   border: none;
   border-radius: var(--border-radius) var(--border-radius) 0 0;
   color: var(--text-color);
   cursor: pointer;
   box-shadow: none;
-  border-bottom: 2px solid transparent;
+  /* Bottom border uses the secondary colour until activated */
+  border-bottom: 2px solid var(--secondary-color);
 }
 
 .tab.active {
-  background: var(--background-color);
+  /* Highlight the active tab with the primary theme colour */
+  background: var(--primary-color);
   border-bottom-color: var(--background-color);
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- invert inactive/active tab colours so the selected option is clearer
- document tab highlight behaviour in pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68682d102c888328bdda12a544f24b82