### PR TITLE
Make last scan links clickable

### DIFF
--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -62,6 +62,7 @@ export const updateMe = (formData) =>
     headers: { 'Content-Type': 'multipart/form-data' }
   });
 export const fetchTeam = (teamId) => axios.get(`/api/teams/${teamId}`);
+export const fetchLastScan = (teamId) => axios.get(`/api/teams/${teamId}/lastscan`);
 export const addTeamMember = (teamId, formData) =>
   axios.post(`/api/teams/${teamId}/members`, formData, {
     headers: { 'Content-Type': 'multipart/form-data' }

--- a/server/routes/teams.js
+++ b/server/routes/teams.js
@@ -10,7 +10,8 @@ const {
   createTeam,
   updateTeam,
   deleteTeam,
-  getTeamsPublic
+  getTeamsPublic,
+  getLastScan
 } = require('../controllers/teamController');
 const Team = require('../models/Team');
 
@@ -18,6 +19,8 @@ const Team = require('../models/Team');
 router.get('/', getTeamsPublic);
 
 router.get('/:teamId', auth, getTeam);
+// Retrieve details about the most recent scan for this team
+router.get('/:teamId/lastscan', auth, getLastScan);
 // Only global admins may modify a team's colour scheme
 router.put('/:teamId/colour', adminAuth, updateColourScheme);
 router.post('/:teamId/members', auth, upload.fields([{ name: 'avatar', maxCount: 1 }]), addMember);


### PR DESCRIPTION
## Summary
- return scanned item id and player id from `getLastScan`
- add helper to Dashboard for building links
- show last scanned item and player as links on the dashboard

## Testing
- `npm test --silent` in `server`
- `npm test --silent` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68684d208a8c8328b2de96ff96bb56f1