### PR TITLE
Update help page text via admin settings

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -26,11 +26,6 @@ export default function Sidebar() {
   return (
     // "mobile-hide" class is hidden under 600 px (see index.css note below)
     <aside className="sidebar mobile-hide">
-      {/* Always‑visible links */}
-      {renderLink('/', 'Home')}
-      {/* Link to the in-app documentation */}
-      {renderLink('/help', 'Help')}
-
       {/* Player‑only links */}
       {token && (
         <>
@@ -43,6 +38,7 @@ export default function Sidebar() {
           {renderLink('/scoreboard', 'Scoreboard')}
           {renderLink('/kudos', 'Kudos')}
           {renderLink('/roguery', 'Gallery')}
+          {renderLink('/help', 'Help')}
         </>
       )}
 

--- a/client/src/pages/AdminSettingsPage.js
+++ b/client/src/pages/AdminSettingsPage.js
@@ -40,6 +40,7 @@ export default function AdminSettingsPage() {
     neumorphicShadows: true,
     roundedCorners: true,
     questionAnswerCooldown: 0,
+    helpText: '',
     scorePerCorrect: 10,
     scorePerSideQuest: 5,
     scorePerCreatedQuest: 20
@@ -79,6 +80,7 @@ export default function AdminSettingsPage() {
       formData.append('fontFamily', settings.fontFamily);
       formData.append('theme', JSON.stringify(settings.theme));
       formData.append('questionAnswerCooldown', settings.questionAnswerCooldown);
+      formData.append('helpText', settings.helpText);
       formData.append('scorePerCorrect', settings.scorePerCorrect);
       formData.append('scorePerSideQuest', settings.scorePerSideQuest);
       formData.append('scorePerCreatedQuest', settings.scorePerCreatedQuest);
@@ -260,6 +262,15 @@ export default function AdminSettingsPage() {
           />
           Rounded Corners
         </label>
+
+        <label>Help Page Text:</label>
+        <textarea
+          value={settings.helpText}
+          onChange={(e) =>
+            setSettings({ ...settings, helpText: e.target.value })
+          }
+          style={{ width: '100%', height: '6rem' }}
+        />
 
         <h3>Alert All Players</h3>
         <input

--- a/client/src/pages/HelpPage.js
+++ b/client/src/pages/HelpPage.js
@@ -1,54 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { fetchSettings } from '../services/api';
 
 // This page provides a high level overview of how the game works
 // and explains each main feature players will encounter.
 export default function HelpPage() {
+  const [helpHtml, setHelpHtml] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchSettings();
+        setHelpHtml(res.data.helpText || '');
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    load();
+  }, []);
+
   return (
-    <div className="card spaced-card">
-      <h2>Help & Quick Start</h2>
-      <p>
-        {/* Very brief explanation for new players */}
-        Treasure Hunt is a team based scavenger hunt. Sign up with your first
-        and last name and either create a new team or join an existing one.
-      </p>
-
-      {/* Step by step instructions for getting into the game quickly */}
-      <h3>Quick Start</h3>
-      <ol>
-        <li>Sign up or log in from the home page.</li>
-        <li>Create a team or join one using another player&apos;s last name.</li>
-        <li>Check your Dashboard to see your current clue.</li>
-        <li>Scan QR codes around the venue to reveal questions.</li>
-        <li>Submit answers and move on to the next clue!</li>
-      </ol>
-
-      {/* Summary of what each section in the sidebar does */}
-      <h3>Features</h3>
-      <ul>
-        <li><strong>Dashboard</strong> – overview of your team and progress.</li>
-        <li><strong>Questions & Clues</strong> – solve riddles to advance.</li>
-        <li><strong>Sidequests</strong> – optional tasks for extra points.</li>
-        <li><strong>Players & Teams</strong> – browse all participants.</li>
-        <li><strong>Scoreboard</strong> – see who&apos;s leading the hunt.</li>
-        <li><strong>Kudos</strong> – vote for players in fun categories.</li>
-        <li>
-          <strong>Rogues Gallery</strong> – view and react to uploaded photos
-          from sidequest submissions.
-        </li>
-        <li>
-          <strong>Progress</strong> – track which questions, clues and sidequests
-          you&apos;ve completed.
-        </li>
-        <li>
-          <strong>Profile</strong> – manage your selfie, team colours and other
-          personal details.
-        </li>
-      </ul>
-      <p>
-        {/* Mention PWA support so users know it works offline */}
-        The site works great as a Progressive Web App. Add it to your home screen
-        to play offline and receive notifications when new clues appear.
-      </p>
-    </div>
+    <div
+      className="card spaced-card"
+      dangerouslySetInnerHTML={{ __html: helpHtml }}
+    />
   );
 }

--- a/server/models/Settings.js
+++ b/server/models/Settings.js
@@ -26,6 +26,33 @@ const settingsSchema = new mongoose.Schema({
   scorePerCreatedQuest: { type: Number, default: 20 },
   // Number of minutes teams must wait before changing a trivia answer
   questionAnswerCooldown: { type: Number, default: 0 },
+  // HTML string displayed on the /help page. Can be edited by admins
+  helpText: {
+    type: String,
+    default: `<h2>Help & Quick Start</h2>
+<p>Treasure Hunt is a team based scavenger hunt. Sign up with your first and last name and either create a new team or join an existing one.</p>
+<h3>Quick Start</h3>
+<ol>
+<li>Sign up or log in from the home page.</li>
+<li>Create a team or join one using another player's last name.</li>
+<li>Check your Dashboard to see your current clue.</li>
+<li>Scan QR codes around the venue to reveal questions.</li>
+<li>Submit answers and move on to the next clue!</li>
+</ol>
+<h3>Features</h3>
+<ul>
+<li><strong>Dashboard</strong> – overview of your team and progress.</li>
+<li><strong>Questions & Clues</strong> – solve riddles to advance.</li>
+<li><strong>Sidequests</strong> – optional tasks for extra points.</li>
+<li><strong>Players & Teams</strong> – browse all participants.</li>
+<li><strong>Scoreboard</strong> – see who's leading the hunt.</li>
+<li><strong>Kudos</strong> – vote for players in fun categories.</li>
+<li><strong>Rogues Gallery</strong> – view and react to uploaded photos from sidequest submissions.</li>
+<li><strong>Progress</strong> – track which questions, clues and sidequests you've completed.</li>
+<li><strong>Profile</strong> – manage your selfie, team colours and other personal details.</li>
+</ul>
+<p>The site works great as a Progressive Web App. Add it to your home screen to play offline and receive notifications when new clues appear.</p>`
+  },
   // Default instructions shown for each side quest type. Admins can
   // customise these strings from the new instructions settings screen.
   sideQuestInstructions: {

--- a/server/server.js
+++ b/server/server.js
@@ -44,7 +44,9 @@ const Settings = require('./models/Settings');
         placeholderUrl: '',
         scorePerCorrect: 10,
         scorePerSideQuest: 5,
-        scorePerCreatedQuest: 20
+        scorePerCreatedQuest: 20,
+        helpText:
+          '<h2>Help & Quick Start</h2><p>Treasure Hunt is a team based scavenger hunt. Sign up with your first and last name and either create a new team or join an existing one.</p><h3>Quick Start</h3><ol><li>Sign up or log in from the home page.</li><li>Create a team or join one using another player\'s last name.</li><li>Check your Dashboard to see your current clue.</li><li>Scan QR codes around the venue to reveal questions.</li><li>Submit answers and move on to the next clue!</li></ol><h3>Features</h3><ul><li><strong>Dashboard</strong> – overview of your team and progress.</li><li><strong>Questions & Clues</strong> – solve riddles to advance.</li><li><strong>Sidequests</strong> – optional tasks for extra points.</li><li><strong>Players & Teams</strong> – browse all participants.</li><li><strong>Scoreboard</strong> – see who\'s leading the hunt.</li><li><strong>Kudos</strong> – vote for players in fun categories.</li><li><strong>Rogues Gallery</strong> – view and react to uploaded photos from sidequest submissions.</li><li><strong>Progress</strong> – track which questions, clues and sidequests you\'ve completed.</li><li><strong>Profile</strong> – manage your selfie, team colours and other personal details.</li></ul><p>The site works great as a Progressive Web App. Add it to your home screen to play offline and receive notifications when new clues appear.</p>'
       });
       console.log('Seeded default settings');
     }


### PR DESCRIPTION
## Summary
- remove Home menu and move Help under Gallery
- fetch help text from settings and render it
- allow editing Help page text from the admin settings
- store default help text in Settings schema and server seed

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68693432aab08328b779a40ba9413737